### PR TITLE
refactor: add rust executor instead of entry field in task block

### DIFF
--- a/examples/base/blk_a/block.oo.yaml
+++ b/examples/base/blk_a/block.oo.yaml
@@ -1,7 +1,6 @@
 type: task_block
-entry:
-  bin: cargo
-  args: [run, "--"]
+executor:
+  name: rust
 inputs_def:
   - handle: my_count
     optional: true

--- a/examples/base/pkg_a/blocks/blk-b/block.oo.yaml
+++ b/examples/base/pkg_a/blocks/blk-b/block.oo.yaml
@@ -1,7 +1,6 @@
 type: task_block
-entry:
-  bin: cargo
-  args: [run, "--"]
+executor:
+  name: rust
 inputs_def:
   - handle: my_count
     optional: true

--- a/examples/concurrency/blk_a/block.oo.yaml
+++ b/examples/concurrency/blk_a/block.oo.yaml
@@ -1,6 +1,5 @@
 type: task_block
-entry:
-  bin: cargo
-  args: [run, "--"]
+executor:
+  name: rust
 outputs_def:
   - handle: my_output

--- a/examples/concurrency/pkg_a/blocks/blk-b/block.oo.yaml
+++ b/examples/concurrency/pkg_a/blocks/blk-b/block.oo.yaml
@@ -1,7 +1,6 @@
 type: task_block
-entry:
-  bin: cargo
-  args: [run, "--"]
+executor:
+  name: rust
 inputs_def:
   - handle: my_count
 outputs_def:

--- a/examples/flows/pkg/pkg_v-0.1.0/blocks/blk-b/block.oo.yaml
+++ b/examples/flows/pkg/pkg_v-0.1.0/blocks/blk-b/block.oo.yaml
@@ -1,7 +1,6 @@
 type: task_block
-entry:
-  bin: cargo
-  args: [run, "--"]
+executor:
+  name: rust
 inputs_def:
   - handle: my_count
     optional: true

--- a/examples/run_to_node/identity/block.oo.yaml
+++ b/examples/run_to_node/identity/block.oo.yaml
@@ -1,7 +1,6 @@
 type: task_block
-entry:
-  bin: cargo
-  args: [run, "--"]
+executor:
+  name: rust
 inputs_def:
   - handle: in
     cache:

--- a/examples/self_block/blocks/blk_d/block.oo.yaml
+++ b/examples/self_block/blocks/blk_d/block.oo.yaml
@@ -1,7 +1,6 @@
 type: task_block
-entry:
-  bin: cargo
-  args: [run, "--"]
+executor:
+  name: rust
 inputs_def:
   - handle: my_count
     optional: true

--- a/examples/service/pkg_a/blocks/blk-b/block.oo.yaml
+++ b/examples/service/pkg_a/blocks/blk-b/block.oo.yaml
@@ -1,7 +1,6 @@
 type: task_block
-entry:
-  bin: cargo
-  args: [run, "--"]
+executor:
+  name: rust
 inputs_def:
   - handle: my_count
 outputs_def:

--- a/manifest_meta/src/lib.rs
+++ b/manifest_meta/src/lib.rs
@@ -3,8 +3,8 @@ use std::sync::Arc;
 use manifest_reader::path_finder::{find_flow, BlockPathFinder};
 pub use manifest_reader::{
     manifest::{
-        HandleName, InputHandle, NodeId, OutputHandle, ServiceExecutorOptions, ShellExecutor,
-        TaskBlockEntry, TaskBlockExecutor, OOMOL_BIN_DATA, OOMOL_SECRET_DATA, OOMOL_VAR_DATA,
+        HandleName, InputHandle, NodeId, OutputHandle, ServiceExecutorOptions, TaskBlockExecutor,
+        OOMOL_BIN_DATA, OOMOL_SECRET_DATA, OOMOL_VAR_DATA,
     },
     JsonValue,
 };
@@ -42,7 +42,9 @@ use utils::error::Result;
 pub mod flow_resolver;
 
 pub fn read_flow_or_block(
-    block_name: &str, mut block_reader: BlockResolver, mut path_finder: BlockPathFinder,
+    block_name: &str,
+    mut block_reader: BlockResolver,
+    mut path_finder: BlockPathFinder,
 ) -> Result<Block> {
     if let Ok(flow_path) = find_flow(block_name) {
         return flow_resolver::read_flow(&flow_path, &mut block_reader, &mut path_finder)

--- a/manifest_meta/src/task.rs
+++ b/manifest_meta/src/task.rs
@@ -2,12 +2,11 @@ use std::path::PathBuf;
 
 use manifest_reader::manifest::{self, InputHandles, OutputHandles};
 
-use crate::{TaskBlockEntry, TaskBlockExecutor};
+use crate::TaskBlockExecutor;
 
 #[derive(Debug, Clone)]
 pub struct TaskBlock {
     pub executor: Option<TaskBlockExecutor>,
-    pub entry: Option<TaskBlockEntry>,
     pub inputs_def: Option<InputHandles>,
     pub outputs_def: Option<OutputHandles>,
     /// block.oo.[yml|yaml] 的路径；如果是 inline block，这个字段为空。
@@ -45,18 +44,18 @@ impl TaskBlock {
 
 impl TaskBlock {
     pub fn from_manifest(
-        manifest: manifest::TaskBlock, path: Option<PathBuf>, package: Option<PathBuf>,
+        manifest: manifest::TaskBlock,
+        path: Option<PathBuf>,
+        package: Option<PathBuf>,
     ) -> Self {
         let manifest::TaskBlock {
             executor,
-            entry,
             inputs_def,
             outputs_def,
         } = manifest;
 
         Self {
             executor,
-            entry,
             inputs_def: inputs_def,
             outputs_def: outputs_def,
             path_str: path.as_ref().map(|path| path.to_string_lossy().to_string()),

--- a/manifest_meta/tests/flow_test/flow-1/block1.oo.yaml
+++ b/manifest_meta/tests/flow_test/flow-1/block1.oo.yaml
@@ -1,10 +1,8 @@
-entry:
-  bin: cargo
-  args: [run, "--"]
+executor:
+  name: rust
 inputs_def:
   - handle: in1
     optional: true
 outputs_def:
   - handle: out1
   - handle: out2
-

--- a/manifest_meta/tests/flow_test/flow-2/block1.oo.yaml
+++ b/manifest_meta/tests/flow_test/flow-2/block1.oo.yaml
@@ -1,10 +1,8 @@
-entry:
-  bin: cargo
-  args: [run, "--"]
+executor:
+  name: rust
 inputs_def:
   - handle: in1
     optional: true
 outputs_def:
   - handle: out1
   - handle: out2
-

--- a/manifest_reader/src/manifest/block/mod.rs
+++ b/manifest_reader/src/manifest/block/mod.rs
@@ -8,4 +8,4 @@ pub use self::flow::FlowBlock;
 pub use self::handle::{InputHandles, OutputHandles};
 pub use self::service::ServiceBlock;
 pub use self::slot::SlotBlock;
-pub use self::task::{ShellExecutor, TaskBlock, TaskBlockEntry, TaskBlockExecutor};
+pub use self::task::{SpawnOptions, TaskBlock, TaskBlockExecutor};

--- a/manifest_reader/src/manifest/block/task.rs
+++ b/manifest_reader/src/manifest/block/task.rs
@@ -44,12 +44,20 @@ pub enum TaskBlockExecutor {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct RustExecutor {
-    pub options: Option<SpawnOptions>,
+    #[serde(default = "default_rust_spawn_options")]
+    pub options: SpawnOptions,
+}
+
+pub fn default_rust_spawn_options() -> SpawnOptions {
+    SpawnOptions {
+        bin: "cargo".to_string(),
+        args: vec!["run".to_string(), "--".to_string()],
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct SpawnOptions {
-    pub bin: Option<String>,
+    pub bin: String,
     #[serde(default)]
     pub args: Vec<String>,
 }

--- a/manifest_reader/src/manifest/block/task.rs
+++ b/manifest_reader/src/manifest/block/task.rs
@@ -1,26 +1,12 @@
-use std::collections::HashMap;
-
 use serde::{Deserialize, Serialize};
 
 use super::{
     handle::{to_input_handles, to_output_handles, InputHandle, OutputHandle},
     InputHandles, OutputHandles,
 };
-
-#[derive(Deserialize, Debug, Clone)]
-pub struct TaskBlockEntry {
-    pub bin: String,
-    #[serde(default)]
-    pub args: Vec<String>,
-    #[serde(default)]
-    pub envs: HashMap<String, String>,
-    pub cwd: Option<String>,
-}
-
 #[derive(Deserialize, Debug, Clone)]
 struct TmpTaskBlock {
     pub executor: Option<TaskBlockExecutor>,
-    pub entry: Option<TaskBlockEntry>,
     pub inputs_def: Option<Vec<InputHandle>>,
     pub outputs_def: Option<Vec<OutputHandle>>,
 }
@@ -29,7 +15,6 @@ impl From<TmpTaskBlock> for TaskBlock {
     fn from(tmp: TmpTaskBlock) -> Self {
         TaskBlock {
             executor: tmp.executor,
-            entry: tmp.entry,
             inputs_def: to_input_handles(tmp.inputs_def),
             outputs_def: to_output_handles(tmp.outputs_def),
         }
@@ -40,7 +25,6 @@ impl From<TmpTaskBlock> for TaskBlock {
 #[serde(from = "TmpTaskBlock")]
 pub struct TaskBlock {
     pub executor: Option<TaskBlockExecutor>,
-    pub entry: Option<TaskBlockEntry>,
     pub inputs_def: Option<InputHandles>,
     pub outputs_def: Option<OutputHandles>,
 }
@@ -54,6 +38,20 @@ pub enum TaskBlockExecutor {
     Python(PythonExecutor),
     #[serde(rename = "shell")]
     Shell(ShellExecutor),
+    #[serde(rename = "rust")]
+    Rust(RustExecutor),
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct RustExecutor {
+    pub options: Option<SpawnOptions>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct SpawnOptions {
+    pub bin: Option<String>,
+    #[serde(default)]
+    pub args: Vec<String>,
 }
 
 impl TaskBlockExecutor {
@@ -62,6 +60,7 @@ impl TaskBlockExecutor {
             TaskBlockExecutor::NodeJS(_) => "nodejs",
             TaskBlockExecutor::Python(_) => "python",
             TaskBlockExecutor::Shell(_) => "shell",
+            TaskBlockExecutor::Rust(_) => "rust",
         }
     }
 
@@ -110,6 +109,7 @@ impl TaskBlockExecutor {
                 })
             }
             TaskBlockExecutor::Shell(_) => false,
+            TaskBlockExecutor::Rust(_) => false,
         }
     }
 }

--- a/manifest_reader/src/manifest/mod.rs
+++ b/manifest_reader/src/manifest/mod.rs
@@ -9,7 +9,7 @@ pub use self::block::handle::{
 
 pub use self::block::{FlowBlock, ServiceBlock, SlotBlock, TaskBlock};
 pub use self::block::{InputHandles, OutputHandles};
-pub use self::block::{ShellExecutor, TaskBlockEntry, TaskBlockExecutor};
+pub use self::block::{SpawnOptions, TaskBlockExecutor};
 pub use self::node::node::{
     FlowNode, FlowNodeSlots, InjectionTarget, Node, NodeId, ServiceNode, SlotNode, SlotNodeBlock,
     TaskNode, TaskNodeBlock, ValueNode,

--- a/manifest_reader/tests/block_manifest_reader_test/blocks1/task-blk1/block.oo.yaml
+++ b/manifest_reader/tests/block_manifest_reader_test/blocks1/task-blk1/block.oo.yaml
@@ -1,6 +1,5 @@
-entry:
-  bin: cargo
-  args: [run, "--"]
+executor:
+  name: rust
 concurrency: 3
 inputs_def:
   - handle: in1


### PR DESCRIPTION
- **refactor: remove entry**
- **refactor: add rust executor, hide shell executor**
- **refactor: use spawn option for rust**
