### PR TITLE
feat: refactor bind path and support load bind path from file

### DIFF
--- a/cli/src/fun.rs
+++ b/cli/src/fun.rs
@@ -1,0 +1,59 @@
+use std::io::BufRead;
+
+use layer::BindPath;
+
+pub fn bind_path_file() -> String {
+    std::env::var("OOCANA_BIND_PATH_FILE").unwrap_or_else(|_| "".to_string())
+}
+
+pub fn bind_path(bind_paths: &Option<Vec<String>>, bind_path_file: &str) -> Vec<BindPath> {
+    let mut bind_path_arg: Vec<BindPath> = vec![];
+
+    if !bind_path_file.is_empty() {
+        let path = std::path::Path::new(&bind_path_file);
+        if path.is_file() {
+            let file = std::fs::File::open(path);
+
+            match file {
+                Ok(file) => {
+                    let reader = std::io::BufReader::new(file);
+                    for line in reader.lines() {
+                        match line {
+                            Ok(line) => {
+                                let parts = line.split(':').collect::<Vec<&str>>();
+                                if parts.len() == 2 {
+                                    bind_path_arg.push(BindPath {
+                                        source: parts[0].to_string(),
+                                        target: parts[1].to_string(),
+                                    });
+                                } else {
+                                    tracing::warn!("bind path file line format error: {line}");
+                                }
+                            }
+                            Err(e) => {
+                                tracing::warn!("bind path file read error: {:?}", e);
+                            }
+                        }
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!("bind path file open error: {:?}", e);
+                }
+            }
+        }
+    }
+
+    if let Some(paths) = bind_paths {
+        for path in paths {
+            let parts = path.split(':').collect::<Vec<&str>>();
+            if parts.len() == 2 {
+                bind_path_arg.push(BindPath {
+                    source: parts[0].to_string(),
+                    target: parts[1].to_string(),
+                });
+            }
+        }
+    }
+
+    bind_path_arg
+}

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -5,13 +5,12 @@ mod parser;
 mod fun;
 
 use fun::bind_path_file;
-use std::{collections::HashSet, io::BufRead};
+use std::collections::HashSet;
 use cache::CacheAction;
-use ::layer::BindPath;
 use one_shot::one_shot::{run_block, BlockArgs};
 
 use clap::{Parser, Subcommand};
-use tracing::{debug, warn};
+use tracing::debug;
 use utils::{error::Result, logger::LogParams};
 use uuid::Uuid;
 
@@ -68,7 +67,7 @@ enum Commands {
         retain_env_keys: Option<Vec<String>>,
         #[arg(help = "env files, only support json file for now, accept multiple input. example: --env-files <file> --env-files <file>. all env file will be processed. first root key will be env's key, the value will be pass through. Only available for python and nodejs executor.", long)]
         env_files: Option<Vec<String>>,
-        #[arg(help = "bind path from file, format is <source_path>:<target_path> line by line, if not provided, it will be find env OOCANA_BIND_PATH_FILE variable", long, default_value_t = bind_path_file())]
+        #[arg(help = "a file path contains multiple bind paths. The file format is <source_path>:<target_path> line by line, if not provided, it will be found in OOCANA_BIND_PATH_FILE env variable", long, default_value_t = bind_path_file())]
         bind_path_file: String,
     },
     Cache {

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -171,7 +171,7 @@ pub fn cli_match() -> Result<()> {
                 exclude_packages: exclude_packages.as_ref()
                 .map(|p| p.split(',').map(|s| s.to_string()).collect()),
                 session_dir: session_path.to_owned(),
-                bind_paths: Some(bind_paths),
+                bind_paths: bind_paths,
                 retain_env_keys: retain_env_keys.to_owned(),
                 env_files: env_files.to_owned(),
             })?

--- a/layer/src/lib.rs
+++ b/layer/src/lib.rs
@@ -10,6 +10,7 @@ mod runtime_layer;
 
 use std::process::Command;
 
+pub use ovmlayer::BindPath;
 pub use package_layer::import_package_layer;
 pub use package_store::{
     delete_all_layer_data, delete_package_layer, get_or_create_package_layer, list_package_layers,

--- a/layer/src/ovmlayer.rs
+++ b/layer/src/ovmlayer.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::process::Command;
 
 fn ovmlayer_bin() -> Command {
@@ -87,7 +86,12 @@ pub fn unmerge_cmd(merge_point: &str) -> Command {
     binding
 }
 
-/// bind: key is the source path, value is the target path
+#[derive(Debug, Clone)]
+pub struct BindPath {
+    pub source: String,
+    pub target: String,
+}
+
 /// run command is executed in merged point. All IO changed will saved in the top layer
 ///
 /// This command need add script shell to execute
@@ -98,20 +102,16 @@ pub fn unmerge_cmd(merge_point: &str) -> Command {
 /// use std::collections::HashMap;
 /// use crate::ovmlayer::run_cmd;
 ///
-/// let mut cmd = run_cmd("merge_point", &Some(HashMap::new()));
+/// let mut cmd = run_cmd("merge_point", &Vec[], &None););
 /// cmd.arg("shell.sh"); // 只能再传入一个参数，这个参数会作为 Command 执行，后续再传入的参数，都是第一个参数执行时的参数内容（以$1, $2, $3...的形式传入），可以参考 zsh -c 的文档。
 /// cmd.output().unwrap();
 /// ```
-pub fn run_cmd(
-    merge_point: &str, bind: &Option<HashMap<String, String>>, work_dir: &Option<String>,
-) -> Command {
+pub fn run_cmd(merge_point: &str, bind_paths: &[BindPath], work_dir: &Option<String>) -> Command {
     let mut binding = ovmlayer_bin();
     let mut options = vec!["run".to_string()];
 
-    if let Some(bind) = bind {
-        for (key, value) in bind.iter() {
-            options.push(format!("--bind={}:{}", key, value));
-        }
+    for bind_path in bind_paths {
+        options.push(format!("--bind={}:{}", bind_path.source, bind_path.target));
     }
 
     if let Some(work_dir) = work_dir {

--- a/layer/src/package_store.rs
+++ b/layer/src/package_store.rs
@@ -1,6 +1,6 @@
 use crate::injection_store::load_injection_store;
 use crate::layer;
-use crate::ovmlayer::LayerType;
+use crate::ovmlayer::{BindPath, LayerType};
 use crate::package_layer::PackageLayer;
 
 use fs2::FileExt;
@@ -66,7 +66,8 @@ pub fn package_layer_status<P: AsRef<Path>>(package_path: P) -> Result<PackageLa
 }
 
 pub fn get_or_create_package_layer<P: AsRef<Path>>(
-    package_path: P, bind_path: Option<HashMap<String, String>>,
+    package_path: P,
+    bind_path: &[BindPath],
 ) -> Result<PackageLayer> {
     let package_path = package_path.as_ref();
     let pkg = package_meta(package_path)?;

--- a/layer/tests/package.rs
+++ b/layer/tests/package.rs
@@ -30,7 +30,7 @@ mod tests {
     #[test]
     fn test_package_layer_api() {
         let d = dirname().join("data").join("vim");
-        let r = get_or_create_package_layer(&d, None);
+        let r = get_or_create_package_layer(&d, &vec![]);
         assert!(r.is_ok(), "Error: {:?}", r.unwrap_err());
         info!("get_package_layer: {:?}", r.unwrap());
 
@@ -51,7 +51,7 @@ mod tests {
     #[test]
     fn test_package_layer_store() {
         let d = dirname().join("data").join("simple");
-        let r = get_or_create_package_layer(&d, None);
+        let r = get_or_create_package_layer(&d, &vec![]);
         assert!(r.is_ok(), "Error: {:?}", r.unwrap_err());
 
         let r = package_layer_status(&d);
@@ -64,7 +64,7 @@ mod tests {
     #[test]
     fn test_validate_package() {
         let d = dirname().join("data").join("simple");
-        let r = get_or_create_package_layer(&d, None);
+        let r = get_or_create_package_layer(&d, &vec![]);
         assert!(r.is_ok(), "Error: {:?}", r.unwrap_err());
         let package_layer = r.unwrap();
         let result = package_layer.validate();
@@ -80,7 +80,7 @@ mod tests {
     #[test]
     fn test_export_import() {
         let d = dirname().join("data").join("simple");
-        let layer = get_or_create_package_layer(&d, None);
+        let layer = get_or_create_package_layer(&d, &vec![]);
         assert!(layer.is_ok(), "Error: {:?}", layer.unwrap_err());
         let package_layer = layer.unwrap();
 

--- a/layer/tests/runtime.rs
+++ b/layer/tests/runtime.rs
@@ -2,7 +2,7 @@
 #[cfg(target_os = "linux")]
 mod tests {
 
-    use std::{collections::HashMap, env::temp_dir};
+    use std::env::temp_dir;
 
     use ctor::ctor;
     use layer::{convert_to_script, *};
@@ -32,10 +32,10 @@ mod tests {
     #[test]
     fn test_run_command_api() {
         let d = dirname().join("data").join("simple");
-        let r = get_or_create_package_layer(&d, None);
+        let r = get_or_create_package_layer(&d, &vec![]);
         assert!(r.is_ok(), "Error: {:?}", r.unwrap_err());
 
-        let runtime_layer = create_runtime_layer(d.to_str().unwrap(), HashMap::new());
+        let runtime_layer = create_runtime_layer(d.to_str().unwrap(), &vec![]);
         assert!(
             runtime_layer.is_ok(),
             "Error: {:?}",
@@ -52,10 +52,11 @@ mod tests {
         work_dir.push("file");
         std::fs::write(&work_dir, "hello aaa").expect("write file failed");
         let bind_dir = work_dir.parent().unwrap().to_str().unwrap().to_string();
-        let mut bind_map = HashMap::new();
-        bind_map.insert(bind_dir.clone(), bind_dir.clone());
 
-        runtime_layer.add_bind_paths(bind_map);
+        runtime_layer.add_bind_paths(&vec![BindPath {
+            source: bind_dir.clone(),
+            target: bind_dir.clone(),
+        }]);
 
         let exec_form_cmd = vec!["ls", work_dir.parent().unwrap().to_str().unwrap()];
 

--- a/mainframe/src/lib.rs
+++ b/mainframe/src/lib.rs
@@ -2,6 +2,7 @@ pub mod reporter;
 pub mod scheduler;
 pub mod worker;
 
+pub use layer::BindPath;
 pub use serde_json::Value as JsonValue;
 
 pub type MessageData = Vec<u8>;

--- a/one_shot/src/one_shot.rs
+++ b/one_shot/src/one_shot.rs
@@ -83,7 +83,7 @@ pub struct BlockArgs<'a> {
     pub default_package: Option<String>,
     pub exclude_packages: Option<Vec<String>>,
     pub session_dir: Option<String>,
-    pub bind_paths: Option<Vec<BindPath>>,
+    pub bind_paths: Vec<BindPath>,
     pub retain_env_keys: Option<Vec<String>>,
     pub env_files: Option<Vec<String>>,
 }
@@ -135,7 +135,7 @@ async fn run_block_async(block_args: BlockArgs<'_>) -> Result<()> {
     let (scheduler_tx, scheduler_rx) = mainframe::scheduler::create(
         session_id.to_owned(),
         addr.to_string(),
-        bind_paths.unwrap_or_default(),
+        bind_paths,
         _scheduler_impl_tx,
         _scheduler_impl_rx,
         default_pkg_path.and_then(|p| p.to_str().map(|s| s.to_owned())),

--- a/one_shot/src/one_shot.rs
+++ b/one_shot/src/one_shot.rs
@@ -1,9 +1,10 @@
 //! Run flow once and exit.
 
 use job::SessionId;
+use mainframe::BindPath;
 use manifest_meta::BlockResolver;
 use manifest_reader::path_finder::BlockPathFinder;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::env;
 use std::fs::{self, metadata};
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
@@ -82,7 +83,7 @@ pub struct BlockArgs<'a> {
     pub default_package: Option<String>,
     pub exclude_packages: Option<Vec<String>>,
     pub session_dir: Option<String>,
-    pub bind_paths: Option<HashMap<String, String>>,
+    pub bind_paths: Option<Vec<BindPath>>,
     pub retain_env_keys: Option<Vec<String>>,
     pub env_files: Option<Vec<String>>,
 }


### PR DESCRIPTION
1. refactor bind path to struct instead of HashMap which not support one source path bind to multiple target path.
2. accept `bind-path-file` argument to load bind path from file, if not provided oocana will search `OOCANA_BIND_PATH_FILE` env variable.
3. this behavior is added in `oocana run` and `oocana package-layer create` subcommand.

file format should be like:

```
source:target
source1:target1
```

Don't support comment, but any line without `:` split to two segment will be ignored.

## Additional

extra bind path has high priority than content in `bind-path-file`.
later bind path with same target path will override.

For example:

```
source1:target
```

`--extra-bind-paths source2:target`


the result will be `source2:target`.