### PR TITLE
feat: use identifier to distinguish executor instead of package

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -1,7 +1,7 @@
 {
   "bootstrap-sha": "572b52301790a3d7505bb43c829246ad4c575278",
-  "bump-minor-pre-major": false,
-  "bump-patch-for-minor-pre-major": false,
+  "bump-minor-pre-major": true,
+  "bump-patch-for-minor-pre-major": true,
   "draft": false,
   "prerelease": false,
   "packages": {

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,7 +195,7 @@ checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
 name = "blk-b"
-version = "0.0.1"
+version = "0.25.0"
 dependencies = [
  "oocana_sdk",
  "tokio",
@@ -203,7 +203,7 @@ dependencies = [
 
 [[package]]
 name = "blk_a"
-version = "0.0.1"
+version = "0.25.0"
 dependencies = [
  "oocana_sdk",
  "tokio",
@@ -211,7 +211,7 @@ dependencies = [
 
 [[package]]
 name = "blk_d"
-version = "0.0.1"
+version = "0.25.0"
 dependencies = [
  "oocana_sdk",
  "tokio",
@@ -358,7 +358,7 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "cli"
-version = "0.24.2"
+version = "0.25.0"
 dependencies = [
  "clap 4.5.32",
  "dirs",
@@ -380,7 +380,7 @@ checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "concurrency-blk-b"
-version = "0.0.1"
+version = "0.25.0"
 dependencies = [
  "oocana_sdk",
  "tokio",
@@ -388,7 +388,7 @@ dependencies = [
 
 [[package]]
 name = "concurrency_blk_a"
-version = "0.0.1"
+version = "0.25.0"
 dependencies = [
  "oocana_sdk",
  "tokio",
@@ -856,7 +856,7 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "identity"
-version = "0.0.1"
+version = "0.25.0"
 dependencies = [
  "oocana_sdk",
  "tokio",
@@ -907,7 +907,7 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "job"
-version = "0.0.1"
+version = "0.25.0"
 dependencies = [
  "derive_more",
  "manifest_meta",
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "layer"
-version = "0.2.1"
+version = "0.25.0"
 dependencies = [
  "ctor",
  "dirs",
@@ -983,7 +983,7 @@ checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
 
 [[package]]
 name = "mainframe"
-version = "0.0.1"
+version = "0.25.0"
 dependencies = [
  "async-trait",
  "flume 0.11.1",
@@ -1000,7 +1000,7 @@ dependencies = [
 
 [[package]]
 name = "mainframe_mqtt"
-version = "0.0.1"
+version = "0.25.0"
 dependencies = [
  "async-trait",
  "flume 0.11.1",
@@ -1018,7 +1018,7 @@ dependencies = [
 
 [[package]]
 name = "manifest_meta"
-version = "0.0.1"
+version = "0.25.0"
 dependencies = [
  "layer",
  "manifest_reader",
@@ -1028,7 +1028,7 @@ dependencies = [
 
 [[package]]
 name = "manifest_reader"
-version = "0.0.1"
+version = "0.25.0"
 dependencies = [
  "derive_more",
  "path-clean",
@@ -1132,7 +1132,7 @@ checksum = "d75b0bedcc4fe52caa0e03d9f1151a323e4aa5e2d78ba3580400cd3c9e2bc4bc"
 
 [[package]]
 name = "one_shot"
-version = "0.0.1"
+version = "0.25.0"
 dependencies = [
  "flume 0.11.1",
  "job",
@@ -1166,7 +1166,7 @@ dependencies = [
 
 [[package]]
 name = "oocana_sdk"
-version = "0.0.1"
+version = "0.25.0"
 dependencies = [
  "clap 3.2.25",
  "job",
@@ -1278,7 +1278,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg_v"
-version = "0.0.1"
+version = "0.25.0"
 dependencies = [
  "oocana_sdk",
  "tokio",
@@ -1573,7 +1573,7 @@ dependencies = [
 
 [[package]]
 name = "runtime"
-version = "0.0.1"
+version = "0.25.0"
 dependencies = [
  "dirs",
  "flume 0.11.1",
@@ -2254,7 +2254,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "utils"
-version = "0.0.1"
+version = "0.25.0"
 dependencies = [
  "anyhow",
  "dirs",

--- a/cli/src/fun.rs
+++ b/cli/src/fun.rs
@@ -37,6 +37,8 @@ pub fn envs(file: &str) -> HashMap<String, String> {
                     tracing::warn!("env file open error: {:?}", e);
                 }
             }
+        } else {
+            tracing::warn!("env file not found: {file}");
         }
     }
 
@@ -81,6 +83,8 @@ pub fn bind_path(bind_paths: &Option<Vec<String>>, bind_path_file: &str) -> Vec<
                     tracing::warn!("bind path file open error: {:?}", e);
                 }
             }
+        } else {
+            tracing::warn!("bind path file not found: {bind_path_file}");
         }
     }
 

--- a/mainframe/src/scheduler.rs
+++ b/mainframe/src/scheduler.rs
@@ -128,7 +128,7 @@ pub enum ExecutePayload<'a> {
         executor: &'a TaskBlockExecutor,
         #[serde(skip_serializing_if = "Option::is_none")]
         outputs: &'a Option<OutputHandles>,
-        package: &'a Option<String>,
+        identifier: &'a Option<String>,
     },
     ServiceBlockPayload {
         session_id: &'a SessionId,
@@ -141,7 +141,7 @@ pub enum ExecutePayload<'a> {
         #[serde(skip_serializing_if = "Option::is_none")]
         outputs: &'a Option<OutputHandles>,
         service_hash: String,
-        package: &'a Option<String>,
+        identifier: &'a Option<String>,
     },
 }
 
@@ -965,7 +965,7 @@ where
                                 service_executor: &service_executor,
                                 outputs: &outputs,
                                 service_hash: service_hash,
-                                package: &identifier,
+                                identifier: &identifier,
                             })
                             .unwrap();
                             impl_tx.run_service_block(&executor_name, data).await;
@@ -1039,7 +1039,7 @@ where
                                 dir: &dir,
                                 executor: &executor,
                                 outputs: &outputs,
-                                package: &identifier,
+                                identifier: &identifier,
                             })
                             .unwrap();
                             impl_tx.run_block(&executor_name, data).await;

--- a/mainframe/src/scheduler.rs
+++ b/mainframe/src/scheduler.rs
@@ -63,6 +63,7 @@ pub enum ReceiveMessage {
         session_id: SessionId,
         executor_name: String,
         package: Option<String>,
+        identifier: Option<String>,
     },
     ExecutorExit {
         session_id: SessionId,
@@ -218,6 +219,7 @@ enum SchedulerCommand {
     SpawnExecutorTimeout {
         executor: String,
         package: Option<String>,
+        identifier: Option<String>,
     },
     ReceiveMessage(MessageData),
     Abort,
@@ -610,6 +612,7 @@ fn spawn_executor(
             txx.send(SchedulerCommand::SpawnExecutorTimeout {
                 executor: executor_bin_clone,
                 package: executor_package,
+                identifier: Some(identifier),
             })
             .unwrap();
         }
@@ -1058,13 +1061,18 @@ where
                             })
                         }
                     }
-                    Ok(SchedulerCommand::SpawnExecutorTimeout { executor, package }) => {
+                    Ok(SchedulerCommand::SpawnExecutorTimeout {
+                        executor,
+                        package,
+                        identifier,
+                    }) => {
                         for (_, sender) in subscribers.iter() {
                             sender
                                 .send(ReceiveMessage::ExecutorTimeout {
                                     session_id: session_id.clone(),
                                     executor_name: executor.clone(),
                                     package: package.clone(),
+                                    identifier: identifier.clone(),
                                 })
                                 .unwrap();
                         }

--- a/mainframe/src/scheduler.rs
+++ b/mainframe/src/scheduler.rs
@@ -1092,10 +1092,11 @@ where
                             match msg {
                                 ReceiveMessage::ExecutorReady {
                                     executor_name,
-                                    package: identifier,
+                                    package,
                                     session_id,
+                                    identifier,
                                 } => {
-                                    // this logic is shoud keep the same with generate_executor_map_name bind
+                                    // same as generate_executor_map_name fn logic
                                     let executor_map_name = if let Some(ref id) = identifier {
                                         format!("{}-{}", executor_name, id)
                                     } else {
@@ -1125,8 +1126,9 @@ where
                                         sender
                                             .send(ReceiveMessage::ExecutorReady {
                                                 executor_name: executor_name.clone(),
-                                                package: identifier.clone(),
+                                                package: package.clone(),
                                                 session_id: session_id.clone(),
+                                                identifier: identifier.clone(),
                                             })
                                             .unwrap();
                                     }

--- a/mainframe/src/scheduler.rs
+++ b/mainframe/src/scheduler.rs
@@ -335,6 +335,7 @@ impl SchedulerTx {
                             Some(ref default_package) => RunningScope::Package {
                                 path: PathBuf::from(default_package.clone()),
                                 name: Some("default".to_string()),
+                                node_id: None,
                             },
                             None => RunningScope::Global { node_id: None },
                         }

--- a/manifest_meta/src/flow.rs
+++ b/manifest_meta/src/flow.rs
@@ -228,9 +228,10 @@ impl SubflowBlock {
 
                     let mut running_scope = match running_target {
                         RunningTarget::Global => RunningScope::default(),
-                        RunningTarget::PackagePath(pkg_path) => RunningScope::Package {
+                        RunningTarget::PackagePath { path, node_id } => RunningScope::Package {
                             name: None,
-                            path: pkg_path,
+                            path,
+                            node_id,
                         },
                         RunningTarget::Node(node_id) => match find_node(&node_id) {
                             Some(_) => RunningScope::Global {
@@ -283,6 +284,7 @@ impl SubflowBlock {
                                 RunningScope::Package {
                                     name: Some(name),
                                     path: pkg_path,
+                                    node_id: None,
                                 }
                             } else {
                                 warn!("package not found: {:?}", name);

--- a/manifest_meta/src/scope.rs
+++ b/manifest_meta/src/scope.rs
@@ -11,9 +11,9 @@ pub enum RunningScope {
     },
     Package {
         path: PathBuf,
-        /// None means the block is package block, if Some, it means the block is inject to this package
+        /// for now None means the block is package block, if Some, it means the block is inject to this package
         name: Option<String>,
-        // node_id: Option<NodeId>,
+        node_id: Option<NodeId>,
     },
 }
 
@@ -65,7 +65,10 @@ pub enum RunningTarget {
     Global,
     Node(NodeId),
     PackageName(String),
-    PackagePath(PathBuf),
+    PackagePath {
+        path: PathBuf,
+        node_id: Option<NodeId>,
+    },
 }
 
 pub fn calculate_running_scope(
@@ -80,7 +83,13 @@ pub fn calculate_running_scope(
 
     // package path is some not means the block is package block
     if block_type == BlockValueType::Pkg && package_path.is_some() {
-        return RunningTarget::PackagePath(package_path.as_ref().unwrap().to_owned());
+        return RunningTarget::PackagePath {
+            path: package_path.as_ref().unwrap().to_owned(),
+            node_id: injection.as_ref().and_then(|inj| match &inj.target {
+                manifest_reader::manifest::InjectionTarget::Node(node_id) => Some(node_id.clone()),
+                _ => None,
+            }),
+        };
     }
 
     match injection {

--- a/manifest_meta/src/scope.rs
+++ b/manifest_meta/src/scope.rs
@@ -32,6 +32,7 @@ impl RunningScope {
         }
     }
 
+    // consider use hash instead of origin string or even global count
     pub fn identifier(&self) -> Option<String> {
         match self {
             RunningScope::Global { node_id } => {
@@ -41,9 +42,14 @@ impl RunningScope {
                     None
                 }
             }
-            RunningScope::Package { path, .. } => {
-                Some(format!("{}", path.to_string_lossy().to_string()))
-            }
+            RunningScope::Package {
+                path,
+                node_id,
+                name: _name,
+            } => match node_id {
+                Some(node_id) => Some(format!("{}-{}", path.display(), node_id)),
+                None => Some(format!("{}", path.display())),
+            },
         }
     }
 

--- a/runtime/src/block_job/listener.rs
+++ b/runtime/src/block_job/listener.rs
@@ -73,11 +73,12 @@ pub fn listen_to_worker(args: ListenerArgs) -> tokio::task::JoinHandle<()> {
                 scheduler::ReceiveMessage::ExecutorReady {
                     executor_name,
                     package: executor_package,
+                    identifier,
                     ..
                 } => {
                     tracing::info!("{executor_name} ({executor_package:?}) executor is ready. block package: {block_scope:?}");
 
-                    if block_scope.identifier() != executor_package {
+                    if block_scope.identifier() != identifier {
                         continue;
                     }
 

--- a/runtime/src/block_job/listener.rs
+++ b/runtime/src/block_job/listener.rs
@@ -142,11 +142,16 @@ pub fn listen_to_worker(args: ListenerArgs) -> tokio::task::JoinHandle<()> {
                 scheduler::ReceiveMessage::ExecutorTimeout {
                     executor_name,
                     package,
+                    identifier,
                     ..
                 } => {
+                    if block_scope.identifier() != identifier {
+                        continue;
+                    }
+
                     let error_message = Some(format!(
-                        "Executor {} for {:?} timeout after 5s",
-                        executor_name, package
+                        "Executor {} identifier {:?} for package {:?} timeout after 5s",
+                        executor_name, identifier, package
                     ));
 
                     reporter.done(&error_message);

--- a/runtime/src/block_job/listener.rs
+++ b/runtime/src/block_job/listener.rs
@@ -76,7 +76,7 @@ pub fn listen_to_worker(args: ListenerArgs) -> tokio::task::JoinHandle<()> {
                     identifier,
                     ..
                 } => {
-                    tracing::info!("{executor_name} ({executor_package:?}) executor is ready. block package: {block_scope:?}");
+                    tracing::info!("{executor_name} {identifier:?} ({executor_package:?}) executor is ready. block package: {block_scope:?}");
 
                     if block_scope.identifier() != identifier {
                         continue;


### PR DESCRIPTION
one package maybe contain multiple same language executor because of spawn feature, use identifier to support this case.