### PR TITLE
feat!: add tmp root parameter

### DIFF
--- a/cli/src/fun.rs
+++ b/cli/src/fun.rs
@@ -1,9 +1,13 @@
 use layer::BindPath;
 
-use std::{collections::HashMap, io::BufRead};
+use std::{collections::HashMap, env::temp_dir, io::BufRead};
 
 pub fn env_file() -> String {
     std::env::var("OOCANA_ENV_FILE").unwrap_or_else(|_| "".to_string())
+}
+
+pub fn temp_root() -> String {
+    std::env::var("OOCANA_TEMP_ROOT").unwrap_or_else(|_| temp_dir().to_string_lossy().to_string())
 }
 
 pub fn envs(file: &str) -> HashMap<String, String> {

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -63,7 +63,7 @@ enum Commands {
         exclude_packages: Option<String>,
         #[arg(help = "a directory which will pass to every block, oocana just check the if the path is exit, if not oocana will create one. Oocana won't do anything about this path, won't delete it. It will be the return value of context.sessionDir or context.session_dir function.", long)]
         session_dir: Option<String>,
-        #[arg(help = "a temporary root directory. oocana will create a sub directory (calculate with the block path hash) in the root directory. The sub directory path will be context.tempDir or context.temp_dir function's return value. This sub directory will be deleted if this session success and will retain if session failed. If not provided, oocana will search OOCANA_TEMP_ROOT. It no value the temp_root will be set to os's temp dir.", long, default_value_t = fun::temp_root())]
+        #[arg(help = "a temporary root directory. oocana will create a sub directory (calculate with the block path hash) in the root directory. The sub directory path will be context.tempDir or context.temp_dir function's return value. This sub directory will be deleted if this session success and will retain if session failed. If not provided, oocana will search OOCANA_TEMP_ROOT. If still no value the temp_root will be use os's temp dir.", long, default_value_t = fun::temp_root())]
         temp_root: String,
         #[arg(help = "when spawn a new process, retain the environment variables(only accept variable name), accept multiple input. example: --retain-env-keys <env> --retain-env-keys <env>", long)]
         retain_env_keys: Option<Vec<String>>,

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -61,8 +61,10 @@ enum Commands {
         default_package: Option<String>,
         #[arg(help = "exclude package, accept package path", long)]
         exclude_packages: Option<String>,
-        #[arg(help = "temporary session path,  It will be the return value of context.sessionDir or context.session_dir function. just a string, oocana just check if it is exist.", long)]
+        #[arg(help = "a directory which will pass to every block, oocana just check the if the path is exit, if not oocana will create one. Oocana won't do anything about this path, won't delete it. It will be the return value of context.sessionDir or context.session_dir function.", long)]
         session_dir: Option<String>,
+        #[arg(help = "a temporary root directory. oocana will create a sub directory (calculate with the block path hash) in the root directory. The sub directory path will be context.tempDir or context.temp_dir function's return value. This sub directory will be deleted if this session success and will retain if session failed. If not provided, oocana will search OOCANA_TEMP_ROOT. It no value the temp_root will be set to os's temp dir.", long, default_value_t = fun::temp_root())]
+        temp_root: String,
         #[arg(help = "when spawn a new process, retain the environment variables(only accept variable name), accept multiple input. example: --retain-env-keys <env> --retain-env-keys <env>", long)]
         retain_env_keys: Option<Vec<String>>,
         #[arg(help = ".env file path, when spawn a executor, these env will pass to this executor. The file format is <key>=<value> line by line like traditional env file. if not provided, oocana will search OOCANA_ENV_FILE env variable", long, default_value_t = env_file())]
@@ -150,7 +152,7 @@ pub fn cli_match() -> Result<()> {
 
     debug!("run cli args: {command:#?} in version: {VERSION}");
     match command {
-        Commands::Run { block, broker, block_search_paths, session, reporter, use_cache, nodes, input_values, exclude_packages, default_package, bind_paths, session_dir: session_path, retain_env_keys, env_file, bind_path_file, verbose: _verbose } => {
+        Commands::Run { block, broker, block_search_paths, session, reporter, use_cache, nodes, input_values, exclude_packages, default_package, bind_paths, session_dir: session_path, retain_env_keys, env_file, bind_path_file, verbose: _verbose, temp_root } => {
 
             let bind_paths = fun::bind_path(bind_paths, bind_path_file);
             let envs = fun::envs(&env_file);

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -179,6 +179,7 @@ pub fn cli_match() -> Result<()> {
                 bind_paths: bind_paths,
                 retain_env_keys: retain_env_keys.to_owned(),
                 envs,
+                temp_root: temp_root.to_owned(),
             })?
         },
         Commands::Cache { action } => {

--- a/mainframe/src/scheduler.rs
+++ b/mainframe/src/scheduler.rs
@@ -482,6 +482,7 @@ fn spawn_executor(
         pass_through_env_keys,
         bind_paths: _bind_paths,
         envs: executor_envs,
+        tmp_dir,
     } = &executor_payload;
 
     // 后面加 -executor 尾缀是一种隐式约定。例如：如果 executor 是 "python"，那么实际上会执行 python-executor。
@@ -497,6 +498,8 @@ fn spawn_executor(
         .package_path()
         .map(|f| f.to_string_lossy().to_string());
 
+    let tmp_dir = tmp_dir.to_string_lossy().to_string();
+
     let mut command = if let Some(ref pkg_layer) = layer {
         let package_path_str = pkg_layer.package_path.to_string_lossy();
 
@@ -508,6 +511,8 @@ fn spawn_executor(
             addr,
             "--session-dir",
             session_dir,
+            "--tmp-dir",
+            tmp_dir.as_str(),
         ];
 
         if identifier.len() > 0 {
@@ -540,6 +545,8 @@ fn spawn_executor(
             addr,
             "--session-dir",
             session_dir,
+            "--tmp-dir",
+            tmp_dir.as_str(),
         ];
 
         if identifier.len() > 0 {
@@ -1203,6 +1210,7 @@ pub struct ExecutorPayload {
     pass_through_env_keys: Vec<String>,
     bind_paths: Vec<BindPath>,
     envs: HashMap<String, String>,
+    tmp_dir: PathBuf,
 }
 
 pub fn create<TT, TR>(
@@ -1216,6 +1224,7 @@ pub fn create<TT, TR>(
     session_dir: String,
     retain_env_keys: Vec<String>,
     envs: HashMap<String, String>,
+    tmp_dir: PathBuf,
 ) -> (SchedulerTx, SchedulerRx<TT, TR>)
 where
     TT: SchedulerTxImpl,
@@ -1239,6 +1248,7 @@ where
                 pass_through_env_keys: retain_env_keys,
                 bind_paths: bind_paths,
                 envs,
+                tmp_dir,
             },
             tx,
             rx,

--- a/one_shot/src/one_shot.rs
+++ b/one_shot/src/one_shot.rs
@@ -157,8 +157,9 @@ async fn run_block_async(block_args: BlockArgs<'_>) -> Result<()> {
     };
 
     if tmp_dir.is_dir() {
-        // do nothing
+        info!("tmp_dir already exists: {:?}", tmp_dir);
     } else if !tmp_dir.exists() {
+        info!("create tmp_dir: {:?}", tmp_dir);
         fs::create_dir_all(&tmp_dir)?;
     } else {
         // TODO: do some clean up

--- a/one_shot/src/one_shot.rs
+++ b/one_shot/src/one_shot.rs
@@ -11,6 +11,8 @@ use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::path::PathBuf;
 use std::process::exit;
 use std::sync::Arc;
+use tracing::{info, warn};
+use utils::calculate_short_hash;
 use utils::error::Result;
 
 const DEFAULT_PORT: u16 = 47688;
@@ -86,6 +88,7 @@ pub struct BlockArgs<'a> {
     pub bind_paths: Vec<BindPath>,
     pub retain_env_keys: Option<Vec<String>>,
     pub envs: HashMap<String, String>,
+    pub temp_root: String,
 }
 
 async fn run_block_async(block_args: BlockArgs<'_>) -> Result<()> {
@@ -104,6 +107,7 @@ async fn run_block_async(block_args: BlockArgs<'_>) -> Result<()> {
         session_dir,
         retain_env_keys,
         envs,
+        temp_root,
     } = block_args;
     let session_id = SessionId::new(session);
     tracing::info!("Session {} started", session_id);
@@ -130,6 +134,35 @@ async fn run_block_async(block_args: BlockArgs<'_>) -> Result<()> {
 
     if metadata(&session_dir).is_err() {
         fs::create_dir_all(&session_dir)?;
+    }
+
+    let tmp_root_path = PathBuf::from(temp_root);
+
+    let temp_directory = {
+        let p = PathBuf::from(block_path);
+        p.file_stem()
+            .map(|f| f.to_string_lossy().to_string())
+            .map(|f| calculate_short_hash(&f, 8))
+            .unwrap_or_else(|| "tmp".to_string())
+    };
+
+    let tmp_dir = if tmp_root_path.is_dir() {
+        tmp_root_path.join(temp_directory)
+    } else {
+        PathBuf::from(format!(
+            "{}/{session_id}",
+            env::temp_dir().to_string_lossy()
+        ))
+        .join(temp_directory)
+    };
+
+    if tmp_dir.is_dir() {
+        // do nothing
+    } else if !tmp_dir.exists() {
+        fs::create_dir_all(&tmp_dir)?;
+    } else {
+        // TODO: do some clean up
+        warn!("tmp_dir is not a directory: {:?}", tmp_dir);
     }
 
     let (scheduler_tx, scheduler_rx) = mainframe::scheduler::create(
@@ -196,6 +229,13 @@ async fn run_block_async(block_args: BlockArgs<'_>) -> Result<()> {
     _ = reporter_handle.await;
 
     tracing::info!("Session {} finished, result: {:?}", session_id, result);
+
+    if result.is_ok() {
+        info!("session finish successfully. remove tmp dir {:?}", tmp_dir);
+        fs::remove_dir_all(&tmp_dir)?;
+    } else {
+        info!("session finish with error. keep tmp dir {:?}", tmp_dir);
+    }
 
     result
 }

--- a/one_shot/src/one_shot.rs
+++ b/one_shot/src/one_shot.rs
@@ -176,6 +176,7 @@ async fn run_block_async(block_args: BlockArgs<'_>) -> Result<()> {
         session_dir,
         retain_env_keys.unwrap_or_default(),
         envs,
+        tmp_dir,
     );
     let scheduler_handle = scheduler_rx.event_loop();
 

--- a/one_shot/src/one_shot.rs
+++ b/one_shot/src/one_shot.rs
@@ -177,7 +177,7 @@ async fn run_block_async(block_args: BlockArgs<'_>) -> Result<()> {
         session_dir,
         retain_env_keys.unwrap_or_default(),
         envs,
-        tmp_dir,
+        tmp_dir.clone(),
     );
     let scheduler_handle = scheduler_rx.event_loop();
 

--- a/one_shot/src/one_shot.rs
+++ b/one_shot/src/one_shot.rs
@@ -142,7 +142,7 @@ async fn run_block_async(block_args: BlockArgs<'_>) -> Result<()> {
         let p = PathBuf::from(block_path);
         p.file_stem()
             .map(|f| f.to_string_lossy().to_string())
-            .map(|f| calculate_short_hash(&f, 8))
+            .map(|f| format!("{}-{}", f, calculate_short_hash(&f, 8)))
             .unwrap_or_else(|| "tmp".to_string())
     };
 


### PR DESCRIPTION
run command accept tmp root argument.

a temporary root directory. oocana will create a sub directory (calculate with the block path hash) in the root directory. The sub directory path will be context.tempDir or context.temp_dir function's return value. This sub directory will be deleted if this session success and will retain if session failed. If not provided, oocana will search OOCANA_TEMP_ROOT. If still no value the temp_root will be use os's temp dir.