### PR TITLE
fix: use workspace instead of hardcode path and reduce hardcode usage

### DIFF
--- a/mainframe/src/scheduler.rs
+++ b/mainframe/src/scheduler.rs
@@ -921,7 +921,7 @@ fn query_executor_state(params: ExecutorCheckParams) -> Result<ExecutorCheckResu
 
         Some(runtime_layer)
     } else {
-        let pkg_dir = PathBuf::from(DEFAULT_WORKSPACE).join(PKG_DIR);
+        let pkg_dir = PathBuf::from(scope.workspace()).join(PKG_DIR);
         if !pkg_dir.exists() {
             std::fs::create_dir_all(&pkg_dir).unwrap_or_else(|e| {
                 tracing::warn!("Failed to create pkg_dir: {:?}, error: {}", pkg_dir, e);

--- a/mainframe/src/scheduler.rs
+++ b/mainframe/src/scheduler.rs
@@ -344,7 +344,7 @@ impl SchedulerTx {
                                 name: Some("default".to_string()),
                                 node_id: None,
                             },
-                            None => RunningScope::Global { node_id: None },
+                            None => RunningScope::default(),
                         }
                     } else {
                         return scope.clone();

--- a/manifest_meta/src/flow.rs
+++ b/manifest_meta/src/flow.rs
@@ -230,11 +230,15 @@ impl SubflowBlock {
                     );
 
                     // if flow_paths s [/a/b/c]/flows/AAA/flow.oo.yaml return [/a/b/c]
-                    // else return flow_paths's grandparent dir
-                    let mut workspace = flow_path.parent().map(|p| p.parent()).flatten();
-                    if workspace.is_some_and(|p| p.file_name().is_some_and(|f| f == "flows")) {
-                        workspace = workspace.and_then(|p| p.parent());
-                    }
+                    // else return flow_paths's parent dir
+                    let grandparent_dir = flow_path.parent().map(|p| p.parent()).flatten();
+                    let workspace = if grandparent_dir
+                        .is_some_and(|p| p.exists() && p.file_name() == Some("flows".as_ref()))
+                    {
+                        grandparent_dir.map(|p| p.parent()).flatten()
+                    } else {
+                        flow_path.parent()
+                    };
 
                     let mut running_scope = match running_target {
                         RunningTarget::Global => RunningScope::default(),

--- a/manifest_meta/src/scope.rs
+++ b/manifest_meta/src/scope.rs
@@ -9,6 +9,7 @@ use crate::InjectionTarget;
 pub enum RunningScope {
     Global {
         node_id: Option<NodeId>,
+        workspace: Option<PathBuf>,
     },
     Package {
         path: PathBuf,
@@ -21,7 +22,9 @@ pub enum RunningScope {
 impl RunningScope {
     pub fn workspace(&self) -> PathBuf {
         match self {
-            RunningScope::Global { .. } => PathBuf::from("/app/workspace"),
+            RunningScope::Global { workspace, .. } => workspace
+                .clone()
+                .unwrap_or_else(|| PathBuf::from("/app/workspace")),
             RunningScope::Package { path, .. } => path.clone(),
         }
     }
@@ -42,7 +45,7 @@ impl RunningScope {
 
     pub fn identifier(&self) -> Option<String> {
         let str = match self {
-            RunningScope::Global { node_id } => {
+            RunningScope::Global { node_id, .. } => {
                 if let Some(node_id) = node_id {
                     Some(format!("{}", node_id))
                 } else {
@@ -71,7 +74,10 @@ impl RunningScope {
 
 impl Default for RunningScope {
     fn default() -> Self {
-        RunningScope::Global { node_id: None }
+        RunningScope::Global {
+            node_id: None,
+            workspace: None,
+        }
     }
 }
 

--- a/manifest_meta/src/scope.rs
+++ b/manifest_meta/src/scope.rs
@@ -19,6 +19,13 @@ pub enum RunningScope {
 }
 
 impl RunningScope {
+    pub fn workspace(&self) -> PathBuf {
+        match self {
+            RunningScope::Global { .. } => PathBuf::from("/app/workspace"),
+            RunningScope::Package { path, .. } => path.clone(),
+        }
+    }
+
     pub fn package_path(&self) -> Option<&Path> {
         match self {
             RunningScope::Package { path, .. } => Some(&path),


### PR DESCRIPTION
- **refactor: use scope workspace**
- **feat: try to find workspace from flow path**

There are still instances of hardcoding, but the number of scenarios where it is used has been minimized as much as possible.