### PR TITLE
feat: implement slot scope follow flow's scope not subflow's

### DIFF
--- a/mainframe/src/scheduler.rs
+++ b/mainframe/src/scheduler.rs
@@ -616,6 +616,7 @@ fn spawn_executor(
             "OOCANA_PKG_DIR".to_string(),
             scope
                 .workspace()
+                .expect("workspace not found") // TODO: better use new struct to avoid unwrap
                 .join(PKG_DIR)
                 .to_string_lossy()
                 .to_string(),
@@ -828,7 +829,11 @@ fn query_executor_state(params: ExecutorCheckParams) -> Result<ExecutorCheckResu
             layer: None,
         });
     } else if no_layer_feature {
-        let pkg_dir = scope.workspace().join(PKG_DIR);
+        // TODO: better use new struct to avoid unwrap
+        let pkg_dir = scope
+            .workspace()
+            .expect("workspace not found")
+            .join(PKG_DIR);
         if !pkg_dir.exists() {
             std::fs::create_dir_all(&pkg_dir).unwrap_or_else(|e| {
                 tracing::warn!("Failed to create pkg_dir: {:?}, error: {}", pkg_dir, e);
@@ -916,7 +921,11 @@ fn query_executor_state(params: ExecutorCheckParams) -> Result<ExecutorCheckResu
 
         Some(runtime_layer)
     } else {
-        let pkg_dir = scope.workspace().join(PKG_DIR);
+        // TODO: better use new struct to avoid unwrap
+        let pkg_dir = scope
+            .workspace()
+            .expect("workspace not found")
+            .join(PKG_DIR);
         if !pkg_dir.exists() {
             std::fs::create_dir_all(&pkg_dir).unwrap_or_else(|e| {
                 tracing::warn!("Failed to create pkg_dir: {:?}, error: {}", pkg_dir, e);

--- a/manifest_meta/src/flow.rs
+++ b/manifest_meta/src/flow.rs
@@ -320,8 +320,9 @@ impl SubflowBlock {
                             node_id,
                         },
                         RunningTarget::Node(node_id) => match find_node(&node_id) {
-                            Some(_) => RunningScope::Current {
+                            Some(_) => RunningScope::Flow {
                                 node_id: Some(node_id),
+                                parent: None,
                             },
                             None => {
                                 warn!("target node not found: {:?}", node_id);

--- a/manifest_meta/src/node/subflow.rs
+++ b/manifest_meta/src/node/subflow.rs
@@ -37,10 +37,12 @@ impl Slot {
 pub struct TaskSlot {
     pub slot_node_id: NodeId,
     pub task: Arc<TaskBlock>,
+    pub scope: RunningScope,
 }
 
 #[derive(Debug, Clone)]
 pub struct SubflowSlot {
     pub slot_node_id: NodeId,
     pub subflow: Arc<SubflowBlock>,
+    pub scope: RunningScope,
 }

--- a/manifest_meta/src/scope.rs
+++ b/manifest_meta/src/scope.rs
@@ -9,7 +9,6 @@ use crate::InjectionTarget;
 pub enum RunningScope {
     Current {
         node_id: Option<NodeId>,
-        workspace: Option<PathBuf>,
     },
     Package {
         path: PathBuf,
@@ -20,17 +19,15 @@ pub enum RunningScope {
 }
 
 impl RunningScope {
+    // TODO: remove workspace
     pub fn new_current(node_id: Option<NodeId>, workspace: Option<PathBuf>) -> Self {
-        RunningScope::Current { node_id, workspace }
+        RunningScope::Current { node_id }
     }
 
-    pub fn workspace(&self) -> PathBuf {
+    pub fn workspace(&self) -> Option<PathBuf> {
         match self {
-            RunningScope::Current { workspace, .. } => workspace
-                .clone()
-                // TODO: remove this hard code
-                .unwrap_or_else(|| PathBuf::from("/app/workspace")),
-            RunningScope::Package { path, .. } => path.clone(),
+            RunningScope::Current { .. } => None,
+            RunningScope::Package { path, .. } => Some(path.clone()),
         }
     }
 
@@ -81,9 +78,8 @@ impl RunningScope {
 
     pub fn clone_with_scope_node_id(&self, scope: &Self) -> Self {
         match self {
-            RunningScope::Current { workspace, .. } => RunningScope::Current {
+            RunningScope::Current { .. } => RunningScope::Current {
                 node_id: scope.node_id(),
-                workspace: workspace.clone(),
             },
             RunningScope::Package { path, name, .. } => RunningScope::Package {
                 node_id: scope.node_id(),
@@ -96,10 +92,7 @@ impl RunningScope {
 
 impl Default for RunningScope {
     fn default() -> Self {
-        RunningScope::Current {
-            node_id: None,
-            workspace: None,
-        }
+        RunningScope::Current { node_id: None }
     }
 }
 

--- a/runtime/src/block_job/block.rs
+++ b/runtime/src/block_job/block.rs
@@ -44,6 +44,7 @@ pub struct RunBlockArgs {
     pub block_status: BlockStatusTx,
     pub nodes: Option<HashSet<NodeId>>,
     pub input_values: Option<String>,
+    pub parent_scope: RunningScope,
     pub scope: RunningScope,
     pub timeout: Option<u64>,
     pub inputs_def_patch: Option<InputDefPatchMap>,
@@ -82,6 +83,7 @@ pub fn run_block(block_args: RunBlockArgs) -> Option<BlockJobHandle> {
         nodes,
         input_values,
         timeout,
+        parent_scope,
         scope,
         inputs_def_patch,
         slot_blocks,
@@ -99,6 +101,7 @@ pub fn run_block(block_args: RunBlockArgs) -> Option<BlockJobHandle> {
                 parent_block_status: block_status,
                 nodes,
                 input_values,
+                parent_scope,
                 scope,
                 slot_blocks: slot_blocks.unwrap_or_default(),
             }

--- a/runtime/src/flow_job/flow.rs
+++ b/runtime/src/flow_job/flow.rs
@@ -525,7 +525,7 @@ fn run_node(node: &Node, shared: &FlowShared, ctx: &mut RunFlowContext) {
         node.block()
     };
 
-    let node_scope = if matches!(node.scope(), RunningScope::Current { .. }) {
+    let node_scope = if matches!(node.scope(), RunningScope::Flow { .. }) {
         let flow_scope = shared.scope.clone();
         flow_scope.clone_with_scope_node_id(&node.scope())
     } else {

--- a/runtime/src/flow_job/flow.rs
+++ b/runtime/src/flow_job/flow.rs
@@ -9,7 +9,6 @@ use uuid::Uuid;
 use crate::{
     block_job::{run_block, BlockJobHandle, RunBlockArgs},
     block_status::{self, BlockStatusTx},
-    flow_job::flow,
     shared::Shared,
 };
 use mainframe::reporter::FlowReporterTx;
@@ -46,6 +45,7 @@ struct FlowShared {
     flow_block: Arc<SubflowBlock>,
     shared: Arc<Shared>,
     stacks: BlockJobStacks,
+    parent_scope: RunningScope,
     scope: RunningScope,
     slot_blocks: HashMap<NodeId, Slot>,
 }
@@ -73,6 +73,7 @@ pub struct RunFlowArgs {
     pub parent_block_status: BlockStatusTx,
     pub nodes: Option<HashSet<NodeId>>,
     pub input_values: Option<String>,
+    pub parent_scope: RunningScope,
     pub scope: RunningScope,
     pub slot_blocks: HashMap<NodeId, Slot>,
 }
@@ -116,6 +117,7 @@ pub fn run_flow(mut flow_args: RunFlowArgs) -> Option<BlockJobHandle> {
         input_values,
         slot_blocks,
         scope,
+        parent_scope,
     } = flow_args;
 
     let reporter = Arc::new(shared.reporter.flow(
@@ -161,6 +163,7 @@ pub fn run_flow(mut flow_args: RunFlowArgs) -> Option<BlockJobHandle> {
         stacks,
         scope,
         slot_blocks,
+        parent_scope,
     };
 
     if let Some(ref origin_nodes) = nodes {
@@ -530,8 +533,7 @@ fn run_node(node: &Node, shared: &FlowShared, ctx: &mut RunFlowContext) {
         let flow_scope = shared.scope.clone();
         flow_scope.clone_with_scope_node_id(&node.scope())
     } else if matches!(node, Node::Slot(_)) {
-        // FIXME: fix this
-        node.scope()
+        shared.parent_scope.clone()
     } else {
         node.scope()
     };
@@ -551,6 +553,7 @@ fn run_node(node: &Node, shared: &FlowShared, ctx: &mut RunFlowContext) {
             block_status: ctx.block_status.clone(),
             nodes: None,
             input_values: None,
+            parent_scope: shared.scope.clone(),
             scope: node_scope,
             timeout: node.timeout(),
             slot_blocks: match node {

--- a/runtime/src/flow_job/flow.rs
+++ b/runtime/src/flow_job/flow.rs
@@ -9,6 +9,7 @@ use uuid::Uuid;
 use crate::{
     block_job::{run_block, BlockJobHandle, RunBlockArgs},
     block_status::{self, BlockStatusTx},
+    flow_job::flow,
     shared::Shared,
 };
 use mainframe::reporter::FlowReporterTx;
@@ -528,6 +529,9 @@ fn run_node(node: &Node, shared: &FlowShared, ctx: &mut RunFlowContext) {
     let node_scope = if matches!(node.scope(), RunningScope::Flow { .. }) {
         let flow_scope = shared.scope.clone();
         flow_scope.clone_with_scope_node_id(&node.scope())
+    } else if matches!(node, Node::Slot(_)) {
+        // FIXME: fix this
+        node.scope()
     } else {
         node.scope()
     };

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -75,6 +75,8 @@ pub async fn run(args: RunArgs<'_>) -> Result<()> {
         env::current_dir().ok()
     };
 
+    let workspace = scope_workspace.expect("workspace not found");
+
     let handle = block_job::run_block({
         block_job::RunBlockArgs {
             block,
@@ -88,7 +90,7 @@ pub async fn run(args: RunArgs<'_>) -> Result<()> {
             input_values,
             timeout: None,
             inputs_def_patch: None,
-            scope: RunningScope::new_current(None, scope_workspace),
+            scope: RunningScope::global(scope_workspace),
             slot_blocks: None,
         }
     });

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -90,6 +90,9 @@ pub async fn run(args: RunArgs<'_>) -> Result<()> {
             input_values,
             timeout: None,
             inputs_def_patch: None,
+            parent_scope: RunningScope::Global {
+                workspace: workspace.clone(),
+            },
             scope: RunningScope::global(workspace),
             slot_blocks: None,
         }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -6,7 +6,7 @@ pub mod shared;
 use manifest_reader::path_finder::BlockPathFinder;
 use std::{
     collections::{HashMap, HashSet},
-    env::{self, current_dir},
+    env::current_dir,
     path::PathBuf,
     sync::Arc,
 };
@@ -72,7 +72,7 @@ pub async fn run(args: RunArgs<'_>) -> Result<()> {
     let scope_workspace = if PathBuf::from("/app/workspace").exists() {
         Some(PathBuf::from("/app/workspace"))
     } else {
-        env::current_dir().ok()
+        current_dir().ok()
     };
 
     let workspace = scope_workspace.expect("workspace not found");

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -90,7 +90,7 @@ pub async fn run(args: RunArgs<'_>) -> Result<()> {
             input_values,
             timeout: None,
             inputs_def_patch: None,
-            scope: RunningScope::global(scope_workspace),
+            scope: RunningScope::global(workspace),
             slot_blocks: None,
         }
     });


### PR DESCRIPTION
fix #79 and #78's sub task.

if slot is not below to a package, the slot should follow flow's scope not subflow's.

for example:

`flows/example/flow.oo.yml`:

```yaml
nodes:
  - subflow: <pkg>::<slot>
    node_id: node-sub
    slots:
      - slot_node_id: replace
        task: counter
    inputs_from:
      - handle: input
        from_node:
          - node_id: node-1
            output_handle: output
```

the counter block will run on example `flow.oo.yml`'s runtime environment not <pkg>'s runtime slot.
> so currently the slot is not support pass variable to subflow. This can be supported in the future.