### PR TITLE
fix: cache value override input value

### DIFF
--- a/manifest_meta/src/node/definition.rs
+++ b/manifest_meta/src/node/definition.rs
@@ -105,7 +105,7 @@ impl Node {
         }
     }
 
-    pub fn has_value_from(&self, handle: &HandleName) -> bool {
+    pub fn has_only_one_value_from(&self, handle: &HandleName) -> bool {
         if let Some(from) = self.from() {
             if let Some(handle_froms) = from.get(handle) {
                 if handle_froms.len() == 1 {
@@ -120,7 +120,7 @@ impl Node {
         false
     }
 
-    pub fn only_has_one_value(&self, handle: &HandleName) -> Option<Option<JsonValue>> {
+    pub fn get_value_from(&self, handle: &HandleName) -> Option<Option<JsonValue>> {
         if let Some(from) = self.from() {
             if let Some(handle_froms) = from.get(handle) {
                 if handle_froms.len() == 1 {
@@ -135,7 +135,7 @@ impl Node {
         None
     }
 
-    pub fn has_from(&self, handle: &HandleName) -> bool {
+    pub fn has_connection(&self, handle: &HandleName) -> bool {
         if let Some(from) = self.from() {
             if let Some(handle_froms) = from.get(handle) {
                 if !handle_froms.is_empty() {

--- a/manifest_meta/src/node/definition.rs
+++ b/manifest_meta/src/node/definition.rs
@@ -138,8 +138,14 @@ impl Node {
     pub fn has_connection(&self, handle: &HandleName) -> bool {
         if let Some(from) = self.from() {
             if let Some(handle_froms) = from.get(handle) {
-                if !handle_froms.is_empty() {
-                    return true;
+                if handle_froms.len() == 1
+                    && handle_froms
+                        .first()
+                        .is_some_and(|f| matches!(f, HandleFrom::FromValue { .. }))
+                {
+                    return false;
+                } else {
+                    return !handle_froms.is_empty();
                 }
             }
         }

--- a/runtime/src/flow_job/node_input_values.rs
+++ b/runtime/src/flow_job/node_input_values.rs
@@ -115,7 +115,7 @@ impl NodeInputValues {
         if let Some(inputs_def) = node.inputs_def() {
             for input_def in inputs_def.values() {
                 if !node.has_connection(&input_def.handle) {
-                    // TODO: don't use input_def.value, use input_froms.value. issue #183
+                    // TODO: issue #183
                     if input_def.value.is_some() {
                         continue;
                     }

--- a/runtime/src/flow_job/node_input_values.rs
+++ b/runtime/src/flow_job/node_input_values.rs
@@ -239,6 +239,11 @@ impl NodeInputValues {
 
         if let Some(input_values) = self.store.get_mut(node_id) {
             for (handle, values) in input_values {
+                if !node.has_connection(handle) {
+                    warn!("node: {} has no connection for handle: {}, but store has this handle's value, maybe the value is from last run cache", node_id, handle);
+                    continue;
+                }
+
                 if let Some(first) = values.pop_front() {
                     value_map.insert(handle.to_owned(), Arc::clone(&first));
 

--- a/runtime/src/flow_job/node_input_values.rs
+++ b/runtime/src/flow_job/node_input_values.rs
@@ -115,7 +115,7 @@ impl NodeInputValues {
         if let Some(inputs_def) = node.inputs_def() {
             for input_def in inputs_def.values() {
                 if !node.has_connection(&input_def.handle) {
-                    // TODO: don't use input_def.value, use input_froms.value
+                    // TODO: don't use input_def.value, use input_froms.value. issue #183
                     if input_def.value.is_some() {
                         continue;
                     }
@@ -151,16 +151,17 @@ impl NodeInputValues {
 
     pub fn node_has_input(&self, node: &Node, handle_name: HandleName) -> bool {
         if let Some(inputs_def) = node.inputs_def() {
+            if node.has_only_one_value_from(&handle_name) {
+                return true;
+            }
+
+            // issue #183
             if !node.has_connection(&handle_name) {
                 return inputs_def
                     .get(&handle_name)
                     .map(|f| f.value.is_some())
                     .unwrap_or(false);
             }
-        }
-
-        if node.has_only_one_value_from(&handle_name) {
-            return true;
         }
 
         if let Some(input_values) = self.store.get(node.node_id()) {
@@ -284,6 +285,7 @@ impl NodeInputValues {
                     continue;
                 }
 
+                // issue #183
                 if let Some(value) = &def.value {
                     value_map.insert(
                         handle.to_owned(),

--- a/runtime/src/flow_job/node_input_values.rs
+++ b/runtime/src/flow_job/node_input_values.rs
@@ -114,9 +114,8 @@ impl NodeInputValues {
     pub fn is_node_fulfill(&self, node: &Node) -> bool {
         if let Some(inputs_def) = node.inputs_def() {
             for input_def in inputs_def.values() {
-                // has_from 为 false，说明没有连线。
-                if !node.has_from(&input_def.handle) {
-                    // 无连线有 value 认为该 input 已满足。
+                if !node.has_connection(&input_def.handle) {
+                    // TODO: don't use input_def.value, use input_froms.value
                     if input_def.value.is_some() {
                         continue;
                     }
@@ -125,7 +124,7 @@ impl NodeInputValues {
                     return false;
                 }
 
-                if node.has_value_from(&input_def.handle) {
+                if node.has_only_one_value_from(&input_def.handle) {
                     continue;
                 }
 
@@ -152,8 +151,7 @@ impl NodeInputValues {
 
     pub fn node_has_input(&self, node: &Node, handle_name: HandleName) -> bool {
         if let Some(inputs_def) = node.inputs_def() {
-            // 没有连线的话，查看是否有 value 值。有值认为也存在。
-            if !node.has_from(&handle_name) {
+            if !node.has_connection(&handle_name) {
                 return inputs_def
                     .get(&handle_name)
                     .map(|f| f.value.is_some())
@@ -161,7 +159,7 @@ impl NodeInputValues {
             }
         }
 
-        if node.has_value_from(&handle_name) {
+        if node.has_only_one_value_from(&handle_name) {
             return true;
         }
 
@@ -268,8 +266,8 @@ impl NodeInputValues {
                     continue;
                 }
 
-                if node.has_value_from(handle) {
-                    if let Some(value) = node.only_has_one_value(handle) {
+                if node.has_only_one_value_from(handle) {
+                    if let Some(value) = node.get_value_from(handle) {
                         value_map.insert(
                             handle.to_owned(),
                             Arc::new(OutputValue {


### PR DESCRIPTION
first run flow once, then remove a node's handle, add a value for that handle.

before this pull request. the node will run with last value cache not the new value we added.