### PR TITLE
refactor: use node input instead of input def and from 

### DIFF
--- a/manifest_meta/src/connections.rs
+++ b/manifest_meta/src/connections.rs
@@ -113,6 +113,19 @@ impl Connections {
                     );
                 }
             }
+
+            // slot input from value is not a common case, we need add it to node_inputs_froms
+            // so that we can use it. in other connection input from value will merged on generate node inputs.
+            // but slot input from value is not merged, so we need to add it to node_inputs_froms.
+            if let Some(value) = slot_input_from.value {
+                self.node_inputs_froms.add(
+                    subflow_node_id.to_owned(),
+                    runtime_handle,
+                    HandleFrom::FromValue {
+                        value: Some(value.clone()),
+                    },
+                );
+            }
         }
     }
 

--- a/manifest_meta/src/flow.rs
+++ b/manifest_meta/src/flow.rs
@@ -524,7 +524,6 @@ impl SubflowBlock {
 
                                                 let mut new_slot_node = slot_node.clone();
                                                 {
-                                                    new_slot_node.inputs_def = Some(new_inputs_def);
                                                     new_slot_node.inputs = new_inputs.into();
                                                 }
 
@@ -635,14 +634,12 @@ impl SubflowBlock {
                             flow,
                             node_id: subflow_node.node_id.to_owned(),
                             timeout: subflow_node.timeout,
-                            inputs_def,
                             inputs: if inputs.is_empty() {
                                 None
                             } else {
                                 Some(inputs)
                             },
                             concurrency: subflow_node.concurrency,
-                            inputs_def_patch: subflow_inputs_def_patch,
                             scope: running_scope,
                             slots: if slot_blocks.is_empty() {
                                 None
@@ -675,14 +672,12 @@ impl SubflowBlock {
                             node_id: service_node.node_id.to_owned(),
                             timeout: service_node.timeout,
                             block: service,
-                            inputs_def,
                             inputs: if inputs.is_empty() {
                                 None
                             } else {
                                 Some(inputs)
                             },
                             concurrency: service_node.concurrency,
-                            inputs_def_patch,
                         }),
                     );
                 }
@@ -840,9 +835,7 @@ impl SubflowBlock {
                             } else {
                                 Some(inputs)
                             },
-                            inputs_def,
                             concurrency: task_node.concurrency,
-                            inputs_def_patch,
                         }),
                     );
                 }
@@ -865,14 +858,12 @@ impl SubflowBlock {
                             node_id: slot_node.node_id.to_owned(),
                             timeout: slot_node.timeout,
                             slot,
-                            inputs_def,
                             inputs: if inputs.is_empty() {
                                 None
                             } else {
                                 Some(inputs)
                             },
                             concurrency: slot_node.concurrency,
-                            inputs_def_patch,
                         }),
                     );
                 }

--- a/manifest_meta/src/flow.rs
+++ b/manifest_meta/src/flow.rs
@@ -474,7 +474,12 @@ impl SubflowBlock {
                                                     })
                                                 {
                                                     if let Some(value) = &input_from.value {
-                                                        // TODO: should add value to NodeInput
+                                                        new_slot_node_inputs
+                                                            .entry(input.handle.clone())
+                                                            .and_modify(|node_input| {
+                                                                node_input.value =
+                                                                    Some(value.clone());
+                                                            });
                                                     }
 
                                                     if input_from

--- a/manifest_meta/src/flow.rs
+++ b/manifest_meta/src/flow.rs
@@ -449,7 +449,10 @@ impl SubflowBlock {
                                                 new_slot_node_inputs.insert(
                                                     input.handle.clone(),
                                                     NodeInput {
-                                                        def: input.clone(),
+                                                        def: InputHandle {
+                                                            remember: true,
+                                                            ..input.clone()
+                                                        },
                                                         patch: None,
                                                         value: None,
                                                         from: None, // from will be added later
@@ -601,7 +604,6 @@ impl SubflowBlock {
                                     handle.to_owned(),
                                     InputHandle {
                                         handle: handle.to_owned(),
-                                        remember: true,
                                         ..input.clone()
                                     },
                                 );

--- a/manifest_meta/src/flow.rs
+++ b/manifest_meta/src/flow.rs
@@ -141,13 +141,21 @@ pub fn generate_node_inputs(
                     })
                 })
             };
+
+            let connection_from = from.map(|f| {
+                f.iter()
+                    .filter(|ff| matches!(ff, crate::HandleFrom::FromValue { .. }))
+                    .cloned()
+                    .collect::<Vec<_>>()
+            });
+
             inputs.insert(
                 handle.to_owned(),
                 NodeInput {
                     def: input_def.clone(),
                     patch,
                     value,
-                    from,
+                    from: connection_from, // this connection is always from node's outputs
                 },
             );
         }

--- a/manifest_meta/src/flow.rs
+++ b/manifest_meta/src/flow.rs
@@ -145,6 +145,7 @@ pub fn generate_node_inputs(
                 tracing::warn!("input: ({}) has value in block's inputs_def, but inputs_from has no value. For now the block's inputs_dev's value will be ignored", handle);
             }
 
+            // we filter out `HandleFrom::FromValue` here, because FromValue will be used to set the value directly
             let connection_from = from.map(|f| {
                 f.iter()
                     .filter(|ff| !matches!(ff, crate::HandleFrom::FromValue { .. }))
@@ -158,7 +159,7 @@ pub fn generate_node_inputs(
                     def: input_def.clone(),
                     patch,
                     value,
-                    from: connection_from, // this connection is always from node's outputs
+                    from: connection_from,
                 },
             );
         }

--- a/manifest_meta/src/flow.rs
+++ b/manifest_meta/src/flow.rs
@@ -433,8 +433,7 @@ impl SubflowBlock {
                                     if let Some(Node::Slot(slot_node)) =
                                         flow.nodes.get(&slotflow_provider.slot_node_id)
                                     {
-                                        let mut new_slot_node_inputs =
-                                            slot_node.inputs.clone().unwrap_or_default();
+                                        let mut new_slot_node_inputs = slot_node.inputs.clone();
                                         let mut additional_flow_inputs_tos: HashMap<
                                             HandleName,
                                             Vec<crate::HandleTo>,
@@ -643,11 +642,7 @@ impl SubflowBlock {
                             flow,
                             node_id: subflow_node.node_id.to_owned(),
                             timeout: subflow_node.timeout,
-                            inputs: if inputs.is_empty() {
-                                None
-                            } else {
-                                Some(inputs)
-                            },
+                            inputs,
                             concurrency: subflow_node.concurrency,
                             scope: running_scope,
                             slots: if slot_blocks.is_empty() {
@@ -681,11 +676,7 @@ impl SubflowBlock {
                             node_id: service_node.node_id.to_owned(),
                             timeout: service_node.timeout,
                             block: service,
-                            inputs: if inputs.is_empty() {
-                                None
-                            } else {
-                                Some(inputs)
-                            },
+                            inputs,
                             concurrency: service_node.concurrency,
                         }),
                     );
@@ -839,11 +830,7 @@ impl SubflowBlock {
                             timeout: task_node.timeout,
                             scope: running_scope,
                             task,
-                            inputs: if inputs.is_empty() {
-                                None
-                            } else {
-                                Some(inputs)
-                            },
+                            inputs,
                             concurrency: task_node.concurrency,
                         }),
                     );
@@ -867,11 +854,7 @@ impl SubflowBlock {
                             node_id: slot_node.node_id.to_owned(),
                             timeout: slot_node.timeout,
                             slot,
-                            inputs: if inputs.is_empty() {
-                                None
-                            } else {
-                                Some(inputs)
-                            },
+                            inputs,
                             concurrency: slot_node.concurrency,
                         }),
                     );

--- a/manifest_meta/src/flow.rs
+++ b/manifest_meta/src/flow.rs
@@ -250,7 +250,7 @@ impl SubflowBlock {
             if matches!(node, manifest::Node::Subflow(ref subflow_node) if subflow_node.slots.as_ref().is_some_and(|s| !s.is_empty()))
             {
                 if let manifest::Node::Subflow(subflow_node) = node {
-                    subflow_node.slots.as_ref().map(|slots| {
+                    if let Some(slots) = subflow_node.slots.as_ref() {
                         for provider in slots {
                             connections.parse_slot_inputs_from(
                                 node.node_id(),
@@ -259,7 +259,7 @@ impl SubflowBlock {
                                 &find_value_node,
                             );
                         }
-                    });
+                    }
                 }
             }
         }
@@ -367,9 +367,10 @@ impl SubflowBlock {
                                         slotflow_provider.inputs_def.as_ref()
                                     {
                                         for input_def in slotflow_node_inputs_def.iter() {
-                                            if !slotflow_inputs_def.as_ref().map_or(false, |d| {
-                                                d.contains_key(&input_def.handle)
-                                            }) {
+                                            if !slotflow_inputs_def
+                                                .as_ref()
+                                                .is_some_and(|d| d.contains_key(&input_def.handle))
+                                            {
                                                 slotflow_inputs_def
                                                     .get_or_insert_with(HashMap::new)
                                                     .insert(

--- a/manifest_meta/src/flow.rs
+++ b/manifest_meta/src/flow.rs
@@ -141,6 +141,9 @@ pub fn generate_node_inputs(
                     })
                 })
             };
+            if value.is_none() && input_def.value.is_some() {
+                tracing::warn!("input: ({}) has value in block's inputs_def, but inputs_from has no value. For now the block's inputs_dev's value will be ignored", handle);
+            }
 
             let connection_from = from.map(|f| {
                 f.iter()
@@ -160,6 +163,7 @@ pub fn generate_node_inputs(
             );
         }
     }
+    tracing::debug!("node inputs: {:?}", inputs);
     inputs
 }
 

--- a/manifest_meta/src/flow.rs
+++ b/manifest_meta/src/flow.rs
@@ -360,8 +360,7 @@ impl SubflowBlock {
                                     let mut slotflow_inputs_def = flow
                                         .nodes
                                         .get(&slotflow_provider.slot_node_id)
-                                        .and_then(|n| n.inputs_def())
-                                        .cloned();
+                                        .and_then(|n| n.inputs_def());
 
                                     if let Some(slotflow_node_inputs_def) =
                                         slotflow_provider.inputs_def.as_ref()

--- a/manifest_meta/src/flow.rs
+++ b/manifest_meta/src/flow.rs
@@ -153,6 +153,10 @@ pub fn generate_node_inputs(
                     .collect::<Vec<_>>()
             });
 
+            if value.is_none() && connection_from.as_ref().is_some_and(|f| !f.is_empty()) {
+                warn!("input: ({}) has no connection and has no value", handle);
+            }
+
             inputs.insert(
                 handle.to_owned(),
                 NodeInput {
@@ -164,7 +168,6 @@ pub fn generate_node_inputs(
             );
         }
     }
-    tracing::debug!("node inputs: {:?}", inputs);
     inputs
 }
 

--- a/manifest_meta/src/flow.rs
+++ b/manifest_meta/src/flow.rs
@@ -512,7 +512,6 @@ impl SubflowBlock {
                                                 let mut new_slot_node = slot_node.clone();
                                                 {
                                                     new_slot_node.inputs_def = Some(new_inputs_def);
-                                                    new_slot_node.from = Some(new_froms);
                                                     new_slot_node.inputs =
                                                         Some(generate_node_inputs(
                                                             &new_slot_node.inputs_def,
@@ -625,7 +624,6 @@ impl SubflowBlock {
                     new_nodes.insert(
                         subflow_node.node_id.to_owned(),
                         Node::Flow(SubflowNode {
-                            from,
                             to,
                             flow,
                             node_id: subflow_node.node_id.to_owned(),
@@ -666,7 +664,6 @@ impl SubflowBlock {
                     new_nodes.insert(
                         service_node.node_id.to_owned(),
                         Node::Service(ServiceNode {
-                            from,
                             to: connections.node_outputs_tos.remove(&service_node.node_id),
                             node_id: service_node.node_id.to_owned(),
                             timeout: service_node.timeout,
@@ -826,7 +823,6 @@ impl SubflowBlock {
                     new_nodes.insert(
                         task_node.node_id.to_owned(),
                         Node::Task(TaskNode {
-                            from,
                             to: connections.node_outputs_tos.remove(&task_node.node_id),
                             node_id: task_node.node_id.to_owned(),
                             timeout: task_node.timeout,
@@ -858,7 +854,6 @@ impl SubflowBlock {
                     new_nodes.insert(
                         slot_node.node_id.to_owned(),
                         Node::Slot(SlotNode {
-                            from,
                             to: connections.node_outputs_tos.remove(&slot_node.node_id),
                             node_id: slot_node.node_id.to_owned(),
                             timeout: slot_node.timeout,

--- a/manifest_meta/src/flow.rs
+++ b/manifest_meta/src/flow.rs
@@ -146,6 +146,7 @@ pub fn generate_node_inputs(
             }
 
             // we filter out `HandleFrom::FromValue` here, because FromValue will be used to set the value directly
+            // TODO: maybe we should use new type to distinguish between `HandleFrom::FromValue` and other `HandleFrom`
             let connection_from = from.map(|f| {
                 f.iter()
                     .filter(|ff| !matches!(ff, crate::HandleFrom::FromValue { .. }))

--- a/manifest_meta/src/flow.rs
+++ b/manifest_meta/src/flow.rs
@@ -413,13 +413,6 @@ impl SubflowBlock {
                                         flow.nodes.get(&slotflow_provider.slot_node_id)
                                     {
                                         if let Node::Slot(slot_node) = slot_node {
-                                            let mut new_inputs_def = slot_node
-                                                .slot
-                                                .as_ref()
-                                                .inputs_def
-                                                .clone()
-                                                .unwrap_or_default();
-
                                             let mut new_inputs =
                                                 slot_node.inputs.clone().unwrap_or_default();
                                             let mut addition_flow_inputs_tos: HashMap<
@@ -435,16 +428,12 @@ impl SubflowBlock {
                                                             &slot_node.node_id,
                                                             &input.handle,
                                                         );
-                                                    if !new_inputs_def.contains_key(&input.handle) {
+                                                    if !new_inputs.contains_key(&input.handle) {
                                                         let runtime_addition_input = InputHandle {
                                                             // this input should be always remembered true
                                                             remember: true,
                                                             ..input.clone()
                                                         };
-                                                        new_inputs_def.insert(
-                                                            runtime_handle_name.clone(),
-                                                            runtime_addition_input.clone(),
-                                                        );
 
                                                         new_inputs.insert(
                                                             runtime_handle_name.clone(),

--- a/manifest_meta/src/flow.rs
+++ b/manifest_meta/src/flow.rs
@@ -513,6 +513,13 @@ impl SubflowBlock {
                                                 {
                                                     new_slot_node.inputs_def = Some(new_inputs_def);
                                                     new_slot_node.from = Some(new_froms);
+                                                    new_slot_node.inputs =
+                                                        Some(generate_node_inputs(
+                                                            &new_slot_node.inputs_def,
+                                                            &new_slot_node.from,
+                                                            &None,
+                                                            &None,
+                                                        ));
                                                 }
 
                                                 // Cannot mutate inside Arc, so clone, update, and re-wrap if needed

--- a/manifest_meta/src/flow.rs
+++ b/manifest_meta/src/flow.rs
@@ -144,7 +144,7 @@ pub fn generate_node_inputs(
 
             let connection_from = from.map(|f| {
                 f.iter()
-                    .filter(|ff| matches!(ff, crate::HandleFrom::FromValue { .. }))
+                    .filter(|ff| !matches!(ff, crate::HandleFrom::FromValue { .. }))
                     .cloned()
                     .collect::<Vec<_>>()
             });

--- a/manifest_meta/src/lib.rs
+++ b/manifest_meta/src/lib.rs
@@ -33,8 +33,8 @@ pub use slot::SlotBlock;
 
 mod node;
 pub use node::{
-    HandleFrom, HandleTo, HandlesFroms, HandlesTos, InputDefPatchMap, Node, NodesHandlesTos,
-    ServiceNode, Slot, SlotNode, SubflowNode,
+    HandleFrom, HandleTo, HandlesFroms, HandlesTos, InputDefPatchMap, Node, HandleSource,
+    NodesHandlesTos, ServiceNode, Slot, SlotNode, SubflowNode,
 };
 
 mod connections;

--- a/manifest_meta/src/lib.rs
+++ b/manifest_meta/src/lib.rs
@@ -33,8 +33,8 @@ pub use slot::SlotBlock;
 
 mod node;
 pub use node::{
-    HandleFrom, HandleTo, HandlesFroms, HandlesTos, InputDefPatchMap, Node, NodesHandlesFroms,
-    NodesHandlesTos, ServiceNode, Slot, SlotNode, SubflowNode,
+    HandleFrom, HandleTo, HandlesFroms, HandlesTos, InputDefPatchMap, Node, NodesHandlesTos,
+    ServiceNode, Slot, SlotNode, SubflowNode,
 };
 
 mod connections;

--- a/manifest_meta/src/node/common.rs
+++ b/manifest_meta/src/node/common.rs
@@ -23,7 +23,6 @@ macro_rules! extend_node_common_field {
             pub timeout: Option<u64>,
             pub to: Option<HandlesTos>,
             pub inputs: Option<HashMap<HandleName, NodeInput>>,
-            pub from: Option<HandlesFroms>,
             pub inputs_def: Option<InputHandles>,
             pub inputs_def_patch: Option<HashMap<HandleName, Vec<InputDefPatch>>>,
             pub concurrency: i32,

--- a/manifest_meta/src/node/common.rs
+++ b/manifest_meta/src/node/common.rs
@@ -10,7 +10,7 @@ pub struct NodeInput {
     pub def: InputHandle,
     pub patch: Option<Vec<InputDefPatch>>,
     pub value: Option<Option<JsonValue>>,
-    pub from: Option<Vec<HandleFrom>>,
+    pub from: Option<Vec<HandleSource>>,
 }
 
 #[macro_export(local_inner_macros)]
@@ -35,6 +35,17 @@ pub type HandlesTos = HashMap<HandleName, Vec<HandleTo>>;
 pub type NodesHandlesTos = HashMap<NodeId, HandlesTos>;
 
 pub type InputDefPatchMap = HashMap<HandleName, Vec<InputDefPatch>>;
+
+#[derive(Debug, Clone)]
+pub enum HandleSource {
+    FlowInput {
+        input_handle: HandleName,
+    },
+    NodeOutput {
+        node_id: NodeId,
+        output_handle: HandleName,
+    },
+}
 
 #[derive(Debug, Clone)]
 pub enum HandleFrom {

--- a/manifest_meta/src/node/common.rs
+++ b/manifest_meta/src/node/common.rs
@@ -32,8 +32,6 @@ pub type HandlesFroms = HashMap<HandleName, Vec<HandleFrom>>;
 
 pub type HandlesTos = HashMap<HandleName, Vec<HandleTo>>;
 
-pub type NodesHandlesFroms = HashMap<NodeId, HandlesFroms>;
-
 pub type NodesHandlesTos = HashMap<NodeId, HandlesTos>;
 
 pub type InputDefPatchMap = HashMap<HandleName, Vec<InputDefPatch>>;

--- a/manifest_meta/src/node/common.rs
+++ b/manifest_meta/src/node/common.rs
@@ -22,7 +22,7 @@ macro_rules! extend_node_common_field {
             pub node_id: NodeId,
             pub timeout: Option<u64>,
             pub to: Option<HandlesTos>,
-            pub inputs: Option<HashMap<HandleName, NodeInput>>,
+            pub inputs: HashMap<HandleName, NodeInput>,
             pub concurrency: i32,
         }
     };

--- a/manifest_meta/src/node/common.rs
+++ b/manifest_meta/src/node/common.rs
@@ -23,8 +23,6 @@ macro_rules! extend_node_common_field {
             pub timeout: Option<u64>,
             pub to: Option<HandlesTos>,
             pub inputs: Option<HashMap<HandleName, NodeInput>>,
-            pub inputs_def: Option<InputHandles>,
-            pub inputs_def_patch: Option<HashMap<HandleName, Vec<InputDefPatch>>>,
             pub concurrency: i32,
         }
     };

--- a/manifest_meta/src/node/common.rs
+++ b/manifest_meta/src/node/common.rs
@@ -1,9 +1,17 @@
 use std::collections::HashMap;
 
 use manifest_reader::{
-    manifest::{HandleName, InputDefPatch, NodeId},
+    manifest::{HandleName, InputDefPatch, InputHandle, NodeId},
     JsonValue,
 };
+
+#[derive(Debug, Clone)]
+pub struct NodeInput {
+    pub def: InputHandle,
+    pub patch: Option<Vec<InputDefPatch>>,
+    pub value: Option<Option<JsonValue>>,
+    pub from: Option<Vec<HandleFrom>>,
+}
 
 #[macro_export(local_inner_macros)]
 macro_rules! extend_node_common_field {
@@ -13,11 +21,12 @@ macro_rules! extend_node_common_field {
             $(pub $field: $type,)*
             pub node_id: NodeId,
             pub timeout: Option<u64>,
-            pub from: Option<HandlesFroms>,
             pub to: Option<HandlesTos>,
+            pub inputs: Option<HashMap<HandleName, NodeInput>>,
+            pub from: Option<HandlesFroms>,
             pub inputs_def: Option<InputHandles>,
-            pub concurrency: i32,
             pub inputs_def_patch: Option<HashMap<HandleName, Vec<InputDefPatch>>>,
+            pub concurrency: i32,
         }
     };
 }

--- a/manifest_meta/src/node/definition.rs
+++ b/manifest_meta/src/node/definition.rs
@@ -6,7 +6,7 @@ use crate::{scope::RunningScope, Block, HandleName, NodeId, ServiceBlock, SlotBl
 
 use crate::extend_node_common_field;
 
-use super::common::{HandlesFroms, HandlesTos, InputDefPatchMap, NodeInput};
+use super::common::{HandlesTos, InputDefPatchMap, NodeInput};
 use super::subflow::SubflowNode;
 
 extend_node_common_field!(TaskNode {

--- a/manifest_meta/src/node/definition.rs
+++ b/manifest_meta/src/node/definition.rs
@@ -141,20 +141,11 @@ impl Node {
     }
 
     pub fn has_connection(&self, handle: &HandleName) -> bool {
-        if let Some(from) = self.from() {
-            if let Some(handle_froms) = from.get(handle) {
-                if handle_froms.len() == 1
-                    && handle_froms
-                        .first()
-                        .is_some_and(|f| matches!(f, HandleFrom::FromValue { .. }))
-                {
-                    return false;
-                } else {
-                    return !handle_froms.is_empty();
-                }
-            }
-        }
-        false
+        self.inputs().map_or(false, |inputs| {
+            inputs
+                .get(handle)
+                .is_some_and(|input| input.from.as_ref().is_some_and(|f| !f.is_empty()))
+        })
     }
 
     pub fn package_path(&self) -> Option<PathBuf> {

--- a/manifest_meta/src/node/definition.rs
+++ b/manifest_meta/src/node/definition.rs
@@ -118,10 +118,8 @@ impl Node {
         if let Some(from) = self.from() {
             if let Some(handle_froms) = from.get(handle) {
                 if handle_froms.len() == 1 {
-                    if let Some(from) = handle_froms.first() {
-                        if let HandleFrom::FromValue { .. } = from {
-                            return true;
-                        }
+                    if let Some(HandleFrom::FromValue { .. }) = handle_froms.first() {
+                        return true;
                     }
                 }
             }
@@ -133,10 +131,8 @@ impl Node {
         if let Some(from) = self.from() {
             if let Some(handle_froms) = from.get(handle) {
                 if handle_froms.len() == 1 {
-                    if let Some(from) = handle_froms.first() {
-                        if let HandleFrom::FromValue { value } = from {
-                            return value.clone();
-                        }
+                    if let Some(HandleFrom::FromValue { value }) = handle_froms.first() {
+                        return value.clone();
                     }
                 }
             }

--- a/manifest_meta/src/node/definition.rs
+++ b/manifest_meta/src/node/definition.rs
@@ -1,7 +1,6 @@
 use std::{collections::HashMap, path::PathBuf, sync::Arc};
 
 use manifest_reader::manifest::{InputDefPatch, InputHandles, OutputHandles};
-use manifest_reader::JsonValue;
 
 use crate::{scope::RunningScope, Block, HandleName, NodeId, ServiceBlock, SlotBlock, TaskBlock};
 
@@ -9,7 +8,6 @@ use crate::extend_node_common_field;
 
 use super::common::{HandlesFroms, HandlesTos, InputDefPatchMap, NodeInput};
 use super::subflow::SubflowNode;
-use super::HandleFrom;
 
 extend_node_common_field!(TaskNode {
     task: Arc<TaskBlock>,
@@ -60,15 +58,6 @@ impl Node {
         }
     }
 
-    pub fn from(&self) -> Option<&HandlesFroms> {
-        match self {
-            Self::Task(task) => task.from.as_ref(),
-            Self::Flow(flow) => flow.from.as_ref(),
-            Self::Slot(slot) => slot.from.as_ref(),
-            Self::Service(service) => service.from.as_ref(),
-        }
-    }
-
     pub fn to(&self) -> Option<&HandlesTos> {
         match self {
             Self::Task(task) => task.to.as_ref(),
@@ -112,32 +101,6 @@ impl Node {
             Self::Slot(slot) => slot.inputs_def_patch.as_ref(),
             Self::Service(service) => service.inputs_def_patch.as_ref(),
         }
-    }
-
-    pub fn has_only_one_value_from(&self, handle: &HandleName) -> bool {
-        if let Some(from) = self.from() {
-            if let Some(handle_froms) = from.get(handle) {
-                if handle_froms.len() == 1 {
-                    if let Some(HandleFrom::FromValue { .. }) = handle_froms.first() {
-                        return true;
-                    }
-                }
-            }
-        }
-        false
-    }
-
-    pub fn get_value_from(&self, handle: &HandleName) -> Option<Option<JsonValue>> {
-        if let Some(from) = self.from() {
-            if let Some(handle_froms) = from.get(handle) {
-                if handle_froms.len() == 1 {
-                    if let Some(HandleFrom::FromValue { value }) = handle_froms.first() {
-                        return value.clone();
-                    }
-                }
-            }
-        }
-        None
     }
 
     pub fn has_connection(&self, handle: &HandleName) -> bool {

--- a/manifest_meta/src/node/definition.rs
+++ b/manifest_meta/src/node/definition.rs
@@ -70,10 +70,8 @@ impl Node {
     pub fn inputs_def(&self) -> Option<InputHandles> {
         let inputs = self.inputs();
         let mut inputs_def = HashMap::new();
-        if let Some(inputs) = inputs {
-            for (handle, input) in inputs.iter() {
-                inputs_def.insert(handle.clone(), input.def.clone());
-            }
+        for (handle, input) in inputs {
+            inputs_def.insert(handle.clone(), input.def.clone());
         }
         if inputs_def.is_empty() {
             None
@@ -91,12 +89,12 @@ impl Node {
         }
     }
 
-    pub fn inputs(&self) -> Option<&HashMap<HandleName, NodeInput>> {
+    pub fn inputs(&self) -> &HashMap<HandleName, NodeInput> {
         match self {
-            Self::Task(task) => task.inputs.as_ref(),
-            Self::Flow(flow) => flow.inputs.as_ref(),
-            Self::Slot(slot) => slot.inputs.as_ref(),
-            Self::Service(service) => service.inputs.as_ref(),
+            Self::Task(task) => &task.inputs,
+            Self::Flow(flow) => &flow.inputs,
+            Self::Slot(slot) => &slot.inputs,
+            Self::Service(service) => &service.inputs,
         }
     }
 
@@ -104,7 +102,7 @@ impl Node {
         let inputs = self.inputs();
         let mut patches = HashMap::new();
 
-        for (handle, input) in inputs.iter().flat_map(|inputs| inputs.iter()) {
+        for (handle, input) in inputs.iter() {
             if let Some(patch) = &input.patch {
                 patches.insert(handle.clone(), patch.clone());
             }
@@ -117,11 +115,9 @@ impl Node {
     }
 
     pub fn has_connection(&self, handle: &HandleName) -> bool {
-        self.inputs().map_or(false, |inputs| {
-            inputs
-                .get(handle)
-                .is_some_and(|input| input.from.as_ref().is_some_and(|f| !f.is_empty()))
-        })
+        self.inputs()
+            .get(handle)
+            .is_some_and(|input| input.from.as_ref().is_some_and(|f| !f.is_empty()))
     }
 
     pub fn package_path(&self) -> Option<PathBuf> {

--- a/manifest_meta/src/node/definition.rs
+++ b/manifest_meta/src/node/definition.rs
@@ -7,7 +7,7 @@ use crate::{scope::RunningScope, Block, HandleName, NodeId, ServiceBlock, SlotBl
 
 use crate::extend_node_common_field;
 
-use super::common::{HandlesFroms, HandlesTos, InputDefPatchMap};
+use super::common::{HandlesFroms, HandlesTos, InputDefPatchMap, NodeInput};
 use super::subflow::SubflowNode;
 use super::HandleFrom;
 
@@ -93,6 +93,15 @@ impl Node {
             Self::Flow(flow) => flow.flow.outputs_def.as_ref(),
             Self::Slot(slot) => slot.slot.outputs_def.as_ref(),
             Self::Service(service) => service.block.outputs_def.as_ref(),
+        }
+    }
+
+    pub fn inputs(&self) -> Option<&HashMap<HandleName, NodeInput>> {
+        match self {
+            Self::Task(task) => task.inputs.as_ref(),
+            Self::Flow(flow) => flow.inputs.as_ref(),
+            Self::Slot(slot) => slot.inputs.as_ref(),
+            Self::Service(service) => service.inputs.as_ref(),
         }
     }
 

--- a/manifest_meta/src/node/mod.rs
+++ b/manifest_meta/src/node/mod.rs
@@ -3,8 +3,7 @@ mod definition;
 pub mod subflow;
 
 pub use common::{
-    HandleFrom, HandleTo, HandlesFroms, HandlesTos, InputDefPatchMap, NodesHandlesFroms,
-    NodesHandlesTos,
+    HandleFrom, HandleTo, HandlesFroms, HandlesTos, InputDefPatchMap, NodesHandlesTos,
 };
 pub use definition::{Node, ServiceNode, SlotNode, TaskNode};
 pub use subflow::{Slot, SubflowNode};

--- a/manifest_meta/src/node/mod.rs
+++ b/manifest_meta/src/node/mod.rs
@@ -3,7 +3,7 @@ mod definition;
 pub mod subflow;
 
 pub use common::{
-    HandleFrom, HandleTo, HandlesFroms, HandlesTos, InputDefPatchMap, NodesHandlesTos,
+    HandleFrom, HandleSource, HandleTo, HandlesFroms, HandlesTos, InputDefPatchMap, NodesHandlesTos,
 };
 pub use definition::{Node, ServiceNode, SlotNode, TaskNode};
 pub use subflow::{Slot, SubflowNode};

--- a/manifest_meta/src/node/subflow.rs
+++ b/manifest_meta/src/node/subflow.rs
@@ -1,7 +1,6 @@
 use super::common::{HandlesTos, NodeInput};
 use crate::{extend_node_common_field, Block, RunningScope, SubflowBlock, TaskBlock};
 use crate::{HandleName, NodeId};
-use manifest_reader::manifest::{InputDefPatch, InputHandles};
 use std::collections::HashMap;
 use std::sync::Arc;
 

--- a/manifest_meta/src/node/subflow.rs
+++ b/manifest_meta/src/node/subflow.rs
@@ -1,4 +1,4 @@
-use super::common::{HandlesFroms, HandlesTos};
+use super::common::{HandlesFroms, HandlesTos, NodeInput};
 use crate::{extend_node_common_field, Block, RunningScope, SubflowBlock, TaskBlock};
 use crate::{HandleName, NodeId};
 use manifest_reader::manifest::{InputDefPatch, InputHandles};

--- a/manifest_meta/src/node/subflow.rs
+++ b/manifest_meta/src/node/subflow.rs
@@ -1,4 +1,4 @@
-use super::common::{HandlesFroms, HandlesTos, NodeInput};
+use super::common::{HandlesTos, NodeInput};
 use crate::{extend_node_common_field, Block, RunningScope, SubflowBlock, TaskBlock};
 use crate::{HandleName, NodeId};
 use manifest_reader::manifest::{InputDefPatch, InputHandles};

--- a/manifest_meta/tests/flow_test.rs
+++ b/manifest_meta/tests/flow_test.rs
@@ -38,15 +38,15 @@ fn it_should_read_flow_block() -> Result<()> {
 
         assert!(matches!(
             from_node1.from.as_ref().unwrap().first().unwrap(),
-            manifest_meta::HandleSource::FromNodeOutput { .. }
+            manifest_meta::HandleSource::NodeOutput { .. }
         ));
-        if let manifest_meta::HandleSource::FromNodeOutput {
+        if let manifest_meta::HandleSource::NodeOutput {
             node_id,
-            node_output_handle,
+            output_handle,
         } = from_node1.from.as_ref().unwrap().first().unwrap()
         {
             assert_eq!(node_id, &node1_id);
-            assert_eq!(node_output_handle, &handle_out2);
+            assert_eq!(output_handle, &handle_out2);
         }
 
         let to_node3 = task_node

--- a/manifest_meta/tests/flow_test.rs
+++ b/manifest_meta/tests/flow_test.rs
@@ -34,22 +34,16 @@ fn it_should_read_flow_block() -> Result<()> {
     let node2 = flow_block.nodes.get(&node2_id).unwrap();
     assert!(matches!(node2, manifest_meta::Node::Task(_)));
     if let manifest_meta::Node::Task(task_node) = node2 {
-        let from_node1 = task_node
-            .from
-            .as_ref()
-            .unwrap()
-            .get(&handle_in1)
-            .unwrap().first()
-            .unwrap();
+        let from_node1 = task_node.inputs.as_ref().unwrap().get(&handle_in1).unwrap();
 
         assert!(matches!(
-            from_node1,
+            from_node1.from.as_ref().unwrap().first().unwrap(),
             manifest_meta::HandleFrom::FromNodeOutput { .. }
         ));
         if let manifest_meta::HandleFrom::FromNodeOutput {
             node_id,
             node_output_handle,
-        } = from_node1
+        } = from_node1.from.as_ref().unwrap().first().unwrap()
         {
             assert_eq!(node_id, &node1_id);
             assert_eq!(node_output_handle, &handle_out2);
@@ -60,7 +54,8 @@ fn it_should_read_flow_block() -> Result<()> {
             .as_ref()
             .unwrap()
             .get(&handle_out1)
-            .unwrap().first()
+            .unwrap()
+            .first()
             .unwrap();
 
         assert!(matches!(
@@ -112,7 +107,8 @@ fn it_should_read_subflow_block_with_inputs_def() -> Result<()> {
     let to_node1 = flow_block
         .flow_inputs_tos
         .get(&handle_flow_in1)
-        .unwrap().first()
+        .unwrap()
+        .first()
         .unwrap();
     assert!(matches!(
         to_node1,
@@ -131,12 +127,16 @@ fn it_should_read_subflow_block_with_inputs_def() -> Result<()> {
     assert_eq!(node1.node_id(), &node1_id);
     assert!(matches!(node1, manifest_meta::Node::Task(_)));
     if let manifest_meta::Node::Task(task_node) = node1 {
-        let from_subflow = task_node
-            .from
+        let from_subflow = &task_node
+            .inputs
             .as_ref()
             .unwrap()
             .get(&handle_in1)
-            .unwrap().first()
+            .unwrap()
+            .from
+            .as_ref()
+            .unwrap()
+            .first()
             .unwrap();
 
         assert!(matches!(

--- a/manifest_meta/tests/flow_test.rs
+++ b/manifest_meta/tests/flow_test.rs
@@ -34,13 +34,13 @@ fn it_should_read_flow_block() -> Result<()> {
     let node2 = flow_block.nodes.get(&node2_id).unwrap();
     assert!(matches!(node2, manifest_meta::Node::Task(_)));
     if let manifest_meta::Node::Task(task_node) = node2 {
-        let from_node1 = task_node.inputs.as_ref().unwrap().get(&handle_in1).unwrap();
+        let from_node1 = task_node.inputs.get(&handle_in1).unwrap();
 
         assert!(matches!(
             from_node1.from.as_ref().unwrap().first().unwrap(),
-            manifest_meta::HandleFrom::FromNodeOutput { .. }
+            manifest_meta::HandleSource::FromNodeOutput { .. }
         ));
-        if let manifest_meta::HandleFrom::FromNodeOutput {
+        if let manifest_meta::HandleSource::FromNodeOutput {
             node_id,
             node_output_handle,
         } = from_node1.from.as_ref().unwrap().first().unwrap()
@@ -129,8 +129,6 @@ fn it_should_read_subflow_block_with_inputs_def() -> Result<()> {
     if let manifest_meta::Node::Task(task_node) = node1 {
         let from_subflow = &task_node
             .inputs
-            .as_ref()
-            .unwrap()
             .get(&handle_in1)
             .unwrap()
             .from
@@ -141,9 +139,9 @@ fn it_should_read_subflow_block_with_inputs_def() -> Result<()> {
 
         assert!(matches!(
             from_subflow,
-            manifest_meta::HandleFrom::FromFlowInput { .. }
+            manifest_meta::HandleSource::FlowInput { .. }
         ));
-        if let manifest_meta::HandleFrom::FromFlowInput { input_handle } = from_subflow {
+        if let manifest_meta::HandleSource::FlowInput { input_handle } = from_subflow {
             assert_eq!(input_handle, &handle_flow_in1);
         }
     }

--- a/manifest_reader/src/path_finder/search_paths.rs
+++ b/manifest_reader/src/path_finder/search_paths.rs
@@ -121,9 +121,9 @@ pub enum BlockValueType {
 const SELF_BLOCK_PREFIX: &str = "self::";
 
 pub fn calculate_block_value_type(block_value: &str) -> BlockValueType {
-    if block_value.starts_with(SELF_BLOCK_PREFIX) {
+    if let Some(prefix) = block_value.strip_prefix(SELF_BLOCK_PREFIX) {
         return BlockValueType::SelfBlock {
-            name: block_value[SELF_BLOCK_PREFIX.len()..].to_string(),
+            name: prefix.to_string(),
         };
     }
 

--- a/runtime/src/flow_job/flow.rs
+++ b/runtime/src/flow_job/flow.rs
@@ -648,7 +648,7 @@ fn run_node(node: &Node, shared: &FlowShared, ctx: &mut RunFlowContext) {
                 Node::Flow(n) => n.slots.clone(),
                 _ => None,
             },
-            inputs_def_patch: node.inputs_def_patch().cloned(),
+            inputs_def_patch: node.inputs_def_patch(),
         }
     });
 

--- a/runtime/src/flow_job/node_input_values.rs
+++ b/runtime/src/flow_job/node_input_values.rs
@@ -112,36 +112,23 @@ impl NodeInputValues {
     }
 
     pub fn is_node_fulfill(&self, node: &Node) -> bool {
-        if let Some(inputs_def) = node.inputs_def() {
-            for input_def in inputs_def.values() {
-                if node.has_only_one_value_from(&input_def.handle) {
+        if let Some(inputs) = node.inputs() {
+            for (handle, input) in inputs {
+                if input.from.as_ref().is_none_or(|f| f.is_empty()) && input.value.is_some() {
                     continue;
                 }
 
-                if !node.has_connection(&input_def.handle) {
-                    // TODO: issue #183
-                    if input_def.value.is_some() {
-                        continue;
-                    }
-
-                    // 未来有其他配置项，作用于无连线状态时，在这里更新即可。现在无连线，同时无 value，继续往下走。会一直卡住。
-                    return false;
-                }
-
-                if let Some(node_values) = self.store.get(node.node_id()) {
-                    let no_handle_value = node_values
-                        .get(&input_def.handle)
-                        .is_none_or(|v| v.is_empty());
-                    let no_memory_value = self
-                        .memory_store
-                        .get(node.node_id())
-                        .and_then(|m| m.get(&input_def.handle))
-                        .is_none_or(|v| v.is_empty());
-
-                    if no_handle_value && no_memory_value {
-                        return false;
-                    }
-                } else {
+                let no_handle_value = self
+                    .store
+                    .get(node.node_id())
+                    .and_then(|m| m.get(handle))
+                    .is_none_or(|v| v.is_empty());
+                let no_memory_value = self
+                    .memory_store
+                    .get(node.node_id())
+                    .and_then(|m| m.get(handle))
+                    .is_none_or(|v| v.is_empty());
+                if no_handle_value && no_memory_value {
                     return false;
                 }
             }
@@ -150,17 +137,11 @@ impl NodeInputValues {
     }
 
     pub fn node_has_input(&self, node: &Node, handle_name: HandleName) -> bool {
-        if let Some(inputs_def) = node.inputs_def() {
-            if node.has_only_one_value_from(&handle_name) {
-                return true;
-            }
-
-            // issue #183
-            if !node.has_connection(&handle_name) {
-                return inputs_def
-                    .get(&handle_name)
-                    .map(|f| f.value.is_some())
-                    .unwrap_or(false);
+        if let Some(inputs) = node.inputs() {
+            if let Some(input) = inputs.get(&handle_name) {
+                if input.from.as_ref().is_none_or(|f| f.is_empty()) && input.value.is_some() {
+                    return true;
+                }
             }
         }
 
@@ -266,14 +247,14 @@ impl NodeInputValues {
             self.remember_value(node_id, &handle, value);
         }
 
-        if let Some(inputs_def) = node.inputs_def() {
-            for (handle, def) in inputs_def {
+        if let Some(inputs) = node.inputs() {
+            for (handle, input) in inputs {
                 if value_map.contains_key(handle) {
                     continue;
                 }
 
-                if node.has_only_one_value_from(handle) {
-                    if let Some(value) = node.get_value_from(handle) {
+                if input.from.as_ref().is_none_or(|f| f.is_empty()) {
+                    if let Some(value) = input.value.as_ref() {
                         value_map.insert(
                             handle.to_owned(),
                             Arc::new(OutputValue {
@@ -284,26 +265,9 @@ impl NodeInputValues {
                     }
                     continue;
                 }
-
-                // issue #183
-                if let Some(value) = &def.value {
-                    value_map.insert(
-                        handle.to_owned(),
-                        Arc::new(OutputValue {
-                            value: value.clone().unwrap_or(serde_json::Value::Null),
-                            cacheable: true,
-                        }),
-                    );
-                    continue;
-                }
-
-                tracing::warn!(
-                    "Node {} has no value for input handle {}",
-                    node.node_id(),
-                    handle
-                );
             }
         }
+
         if value_map.is_empty() {
             None
         } else {

--- a/runtime/src/flow_job/node_input_values.rs
+++ b/runtime/src/flow_job/node_input_values.rs
@@ -136,9 +136,9 @@ impl NodeInputValues {
         true
     }
 
-    pub fn node_has_input(&self, node: &Node, handle_name: HandleName) -> bool {
+    pub fn node_has_input(&self, node: &Node, handle_name: &HandleName) -> bool {
         if let Some(inputs) = node.inputs() {
-            if let Some(input) = inputs.get(&handle_name) {
+            if let Some(input) = inputs.get(handle_name) {
                 if input.from.as_ref().is_none_or(|f| f.is_empty()) && input.value.is_some() {
                     return true;
                 }
@@ -146,7 +146,7 @@ impl NodeInputValues {
         }
 
         if let Some(input_values) = self.store.get(node.node_id()) {
-            if let Some(values) = input_values.get(&handle_name) {
+            if let Some(values) = input_values.get(handle_name) {
                 return !values.is_empty();
             }
         }

--- a/runtime/src/flow_job/node_input_values.rs
+++ b/runtime/src/flow_job/node_input_values.rs
@@ -112,36 +112,33 @@ impl NodeInputValues {
     }
 
     pub fn is_node_fulfill(&self, node: &Node) -> bool {
-        if let Some(inputs) = node.inputs() {
-            for (handle, input) in inputs {
-                if input.from.as_ref().is_none_or(|f| f.is_empty()) && input.value.is_some() {
-                    continue;
-                }
+        for (handle, input) in node.inputs() {
+            if input.from.as_ref().is_none_or(|f| f.is_empty()) && input.value.is_some() {
+                continue;
+            }
 
-                let no_handle_value = self
-                    .store
-                    .get(node.node_id())
-                    .and_then(|m| m.get(handle))
-                    .is_none_or(|v| v.is_empty());
-                let no_memory_value = self
-                    .memory_store
-                    .get(node.node_id())
-                    .and_then(|m| m.get(handle))
-                    .is_none_or(|v| v.is_empty());
-                if no_handle_value && no_memory_value {
-                    return false;
-                }
+            let no_handle_value = self
+                .store
+                .get(node.node_id())
+                .and_then(|m| m.get(handle))
+                .is_none_or(|v| v.is_empty());
+            let no_memory_value = self
+                .memory_store
+                .get(node.node_id())
+                .and_then(|m| m.get(handle))
+                .is_none_or(|v| v.is_empty());
+            if no_handle_value && no_memory_value {
+                return false;
             }
         }
+
         true
     }
 
     pub fn node_has_input(&self, node: &Node, handle_name: &HandleName) -> bool {
-        if let Some(inputs) = node.inputs() {
-            if let Some(input) = inputs.get(handle_name) {
-                if input.from.as_ref().is_none_or(|f| f.is_empty()) && input.value.is_some() {
-                    return true;
-                }
+        if let Some(input) = node.inputs().get(handle_name) {
+            if input.from.as_ref().is_none_or(|f| f.is_empty()) && input.value.is_some() {
+                return true;
             }
         }
 
@@ -188,13 +185,11 @@ impl NodeInputValues {
 
     pub fn remove_input_values(&mut self, node: &Node, from_nodes: &HashSet<NodeId>) {
         if let Some(inputs_map) = self.store.get_mut(node.node_id()) {
-            if let Some(inputs) = node.inputs() {
-                for (handle, node_input) in inputs {
-                    for from in node_input.from.iter().flatten() {
-                        if let manifest_meta::HandleSource::NodeOutput { node_id, .. } = from {
-                            if from_nodes.contains(node_id) {
-                                inputs_map.remove(handle);
-                            }
+            for (handle, node_input) in node.inputs() {
+                for from in node_input.from.iter().flatten() {
+                    if let manifest_meta::HandleSource::NodeOutput { node_id, .. } = from {
+                        if from_nodes.contains(node_id) {
+                            inputs_map.remove(handle);
                         }
                     }
                 }
@@ -247,24 +242,22 @@ impl NodeInputValues {
             self.remember_value(node_id, &handle, value);
         }
 
-        if let Some(inputs) = node.inputs() {
-            for (handle, input) in inputs {
-                if value_map.contains_key(handle) {
-                    continue;
-                }
+        for (handle, input) in node.inputs() {
+            if value_map.contains_key(handle) {
+                continue;
+            }
 
-                if input.from.as_ref().is_none_or(|f| f.is_empty()) {
-                    if let Some(value) = input.value.as_ref() {
-                        value_map.insert(
-                            handle.to_owned(),
-                            Arc::new(OutputValue {
-                                value: value.clone().unwrap_or(serde_json::Value::Null),
-                                cacheable: true,
-                            }),
-                        );
-                    }
-                    continue;
+            if input.from.as_ref().is_none_or(|f| f.is_empty()) {
+                if let Some(value) = input.value.as_ref() {
+                    value_map.insert(
+                        handle.to_owned(),
+                        Arc::new(OutputValue {
+                            value: value.clone().unwrap_or(serde_json::Value::Null),
+                            cacheable: true,
+                        }),
+                    );
                 }
+                continue;
             }
         }
 

--- a/runtime/src/flow_job/node_input_values.rs
+++ b/runtime/src/flow_job/node_input_values.rs
@@ -188,9 +188,9 @@ impl NodeInputValues {
 
     pub fn remove_input_values(&mut self, node: &Node, from_nodes: &HashSet<NodeId>) {
         if let Some(inputs_map) = self.store.get_mut(node.node_id()) {
-            if let Some(froms) = node.from() {
-                for (handle, froms) in froms {
-                    for from in froms {
+            if let Some(inputs) = node.inputs() {
+                for (handle, node_input) in inputs {
+                    for from in node_input.from.iter().flatten() {
                         if let manifest_meta::HandleFrom::FromNodeOutput { node_id, .. } = from {
                             if from_nodes.contains(node_id) {
                                 inputs_map.remove(handle);

--- a/runtime/src/flow_job/node_input_values.rs
+++ b/runtime/src/flow_job/node_input_values.rs
@@ -216,8 +216,11 @@ impl NodeInputValues {
 
         if let Some(input_values) = self.store.get_mut(node_id) {
             for (handle, values) in input_values {
-                if !node.has_connection(handle) {
-                    warn!("node: {} has no connection for handle: {}, but store has this handle's value, maybe the value is from last run cache", node_id, handle);
+                // this is a workaround, the best way is when flow or block is edited, clear the cache or run flow without `cache`
+                if !node.has_connection(handle)
+                    && node.inputs().get(handle).is_some_and(|i| i.value.is_some())
+                {
+                    warn!("Node {} handle {} has no connection with a static value exist. oocana will use handle's static value instead of the value in node store to avoid cache effect.", node_id, handle);
                     continue;
                 }
 

--- a/runtime/src/flow_job/node_input_values.rs
+++ b/runtime/src/flow_job/node_input_values.rs
@@ -191,7 +191,7 @@ impl NodeInputValues {
             if let Some(inputs) = node.inputs() {
                 for (handle, node_input) in inputs {
                     for from in node_input.from.iter().flatten() {
-                        if let manifest_meta::HandleFrom::FromNodeOutput { node_id, .. } = from {
+                        if let manifest_meta::HandleSource::NodeOutput { node_id, .. } = from {
                             if from_nodes.contains(node_id) {
                                 inputs_map.remove(handle);
                             }

--- a/runtime/src/flow_job/run_to_node.rs
+++ b/runtime/src/flow_job/run_to_node.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 
-use manifest_meta::{HandleFrom, Node, NodeId, SubflowBlock};
+use manifest_meta::{Node, NodeId, SubflowBlock};
 
 use super::node_input_values::NodeInputValues;
 
@@ -67,8 +67,8 @@ fn calc_node_deps(
                 continue;
             }
 
-            for handle_from in input.from.iter().flatten() {
-                if let HandleFrom::FromNodeOutput { node_id, .. } = handle_from {
+            for node_source in input.from.iter().flatten() {
+                if let manifest_meta::HandleSource::NodeOutput { node_id, .. } = node_source {
                     if !should_run_nodes.contains(node_id) {
                         if let Some(dependent_node) = flow.nodes.get(node_id) {
                             calc_node_deps(

--- a/runtime/src/flow_job/run_to_node.rs
+++ b/runtime/src/flow_job/run_to_node.rs
@@ -58,26 +58,19 @@ fn calc_node_deps(
         }
     }
 
-    if let Some(inputs) = node.inputs() {
-        for (handle_name, input) in inputs.iter() {
-            if node_input_values
-                .as_ref()
-                .map_or(false, |values| values.node_has_input(node, handle_name))
-            {
-                continue;
-            }
+    for (handle_name, input) in node.inputs() {
+        if node_input_values
+            .as_ref()
+            .map_or(false, |values| values.node_has_input(node, handle_name))
+        {
+            continue;
+        }
 
-            for node_source in input.from.iter().flatten() {
-                if let manifest_meta::HandleSource::NodeOutput { node_id, .. } = node_source {
-                    if !should_run_nodes.contains(node_id) {
-                        if let Some(dependent_node) = flow.nodes.get(node_id) {
-                            calc_node_deps(
-                                dependent_node,
-                                flow,
-                                should_run_nodes,
-                                node_input_values,
-                            );
-                        }
+        for node_source in input.from.iter().flatten() {
+            if let manifest_meta::HandleSource::NodeOutput { node_id, .. } = node_source {
+                if !should_run_nodes.contains(node_id) {
+                    if let Some(dependent_node) = flow.nodes.get(node_id) {
+                        calc_node_deps(dependent_node, flow, should_run_nodes, node_input_values);
                     }
                 }
             }

--- a/runtime/src/shared.rs
+++ b/runtime/src/shared.rs
@@ -2,7 +2,7 @@ use job::SessionId;
 use std::{collections::HashMap, sync::Arc};
 
 use mainframe::{reporter::ReporterTx, scheduler::SchedulerTx};
-use manifest_meta::{HandleName, NodesHandlesFroms, NodesHandlesTos, SubflowBlock};
+use manifest_meta::{HandleName, SubflowBlock};
 use utils::output::OutputValue;
 
 use crate::delay_abort::DelayAbortTx;
@@ -19,6 +19,4 @@ pub struct Shared {
 pub struct FlowContext {
     pub flow_block: Arc<SubflowBlock>,
     pub flow_inputs: Option<HashMap<HandleName, Arc<OutputValue>>>,
-    pub slots_inputs_to: Option<NodesHandlesTos>,
-    pub slots_outputs_from: Option<NodesHandlesFroms>,
 }


### PR DESCRIPTION
fix #183 

Merge `inputs_def` `inputs_def_patch` `from` field to `NodeInput` struct. And add `input_def.value` to `NodeInput` struct.

```Rust
#[derive(Debug, Clone)]
pub struct NodeInput {
    pub def: InputHandle,
    pub patch: Option<Vec<InputDefPatch>>,
    pub value: Option<Option<JsonValue>>,
    pub from: Option<Vec<HandleFrom>>,
}
```