### PR TITLE
fix: cache block's last execute value not latest value

### DIFF
--- a/runtime/src/flow_job/flow.rs
+++ b/runtime/src/flow_job/flow.rs
@@ -1236,13 +1236,6 @@ fn produce_new_value(
                     0
                 };
 
-                // even if the node is not in the run_nodes list, we still need to insert value, because we can use this value with cache option in next run.
-                ctx.node_input_values.insert(
-                    node_id.to_owned(),
-                    input_handle.to_owned(),
-                    Arc::clone(value),
-                );
-
                 // if limit_nodes is Some, output should only send to these nodes
                 if limit_nodes
                     .as_ref()
@@ -1250,6 +1243,9 @@ fn produce_new_value(
                 {
                     continue;
                 }
+
+                ctx.node_input_values
+                    .insert(node_id, input_handle, Arc::clone(value));
 
                 if run_next_node {
                     if let Some(node) = shared.flow_block.nodes.get(node_id) {

--- a/runtime/src/flow_job/flow.rs
+++ b/runtime/src/flow_job/flow.rs
@@ -1241,6 +1241,13 @@ fn produce_new_value(
                     .as_ref()
                     .is_some_and(|nodes| !nodes.contains(node_id))
                 {
+                    // if target node is not in running nodes, we just update cache value so that we can use these value in next run.
+                    // Normally, cache values are only cached before the block is executed. This is an exception.
+                    ctx.node_input_values.update_cache_value(
+                        node_id,
+                        input_handle,
+                        Arc::clone(value),
+                    );
                     continue;
                 }
 

--- a/runtime/src/flow_job/flow.rs
+++ b/runtime/src/flow_job/flow.rs
@@ -1412,7 +1412,7 @@ pub fn get_flow_cache_path(flow: &str) -> Option<PathBuf> {
 
 fn save_flow_cache(node_input_values: &NodeInputValues, flow: &str) {
     if let Some(cache_path) = get_flow_cache_path(flow) {
-        if let Err(e) = node_input_values.save_last_value(cache_path) {
+        if let Err(e) = node_input_values.save_cache(cache_path) {
             warn!("failed to save cache: {}", e);
         }
     } else if let Some(meta_path) = utils::cache::cache_meta_file_path() {
@@ -1420,7 +1420,7 @@ fn save_flow_cache(node_input_values: &NodeInputValues, flow: &str) {
             .unwrap_or(std::env::temp_dir())
             .join(Uuid::new_v4().to_string() + ".json");
 
-        if let Err(e) = node_input_values.save_last_value(cache_path.clone()) {
+        if let Err(e) = node_input_values.save_cache(cache_path.clone()) {
             warn!("failed to save cache: {}", e);
             return;
         }

--- a/runtime/src/flow_job/node_input_values.rs
+++ b/runtime/src/flow_job/node_input_values.rs
@@ -74,13 +74,13 @@ impl NodeInputValues {
         }
     }
 
-    pub fn insert(&mut self, node_id: NodeId, handle_name: HandleName, value: Arc<OutputValue>) {
+    pub fn insert(&mut self, node_id: &NodeId, handle_name: &HandleName, value: Arc<OutputValue>) {
         self.store
-            .entry(node_id.clone())
+            .entry(node_id.to_owned())
             .or_default()
-            .entry(handle_name.clone())
+            .entry(handle_name.to_owned())
             .or_default()
-            .push_back(Arc::clone(&value));
+            .push_back(value);
     }
 
     pub fn is_node_fulfill(&self, node: &Node) -> bool {

--- a/runtime/src/flow_job/node_input_values.rs
+++ b/runtime/src/flow_job/node_input_values.rs
@@ -24,7 +24,7 @@ pub struct NodeInputValues {
     store: NodeInputStore,
     // used to store last values for each node input when `remember` is true
     memory_store: NodeInputStore,
-    last_values: Option<NodeInputStore>,
+    cache_value_store: Option<NodeInputStore>,
 }
 
 impl NodeInputValues {
@@ -32,7 +32,7 @@ impl NodeInputValues {
         Self {
             store: HashMap::new(),
             memory_store: HashMap::new(),
-            last_values: if save_cache {
+            cache_value_store: if save_cache {
                 Some(HashMap::new())
             } else {
                 None
@@ -54,14 +54,14 @@ impl NodeInputValues {
                 Ok(store) => Self {
                     store: store.clone(),
                     memory_store: HashMap::new(),
-                    last_values: Some(store),
+                    cache_value_store: Some(store),
                 },
                 Err(e) => {
                     warn!("Failed to deserialize: {:?}", e);
                     Self {
                         store: HashMap::new(),
                         memory_store: HashMap::new(),
-                        last_values,
+                        cache_value_store: last_values,
                     }
                 }
             }
@@ -69,7 +69,7 @@ impl NodeInputValues {
             Self {
                 store: HashMap::new(),
                 memory_store: HashMap::new(),
-                last_values,
+                cache_value_store: last_values,
             }
         }
     }
@@ -137,7 +137,7 @@ impl NodeInputValues {
     }
 
     pub fn save_cache(&self, path: PathBuf) -> Result<(), String> {
-        if let Some(last_values) = &self.last_values {
+        if let Some(last_values) = &self.cache_value_store {
             // save hash map to file
             let json_string = serde_json::to_string(&last_values)
                 .map_err(|e| format!("failed to serialize {}", e))?;
@@ -241,7 +241,7 @@ impl NodeInputValues {
                 continue;
             }
 
-            if let Some(last_values) = &mut self.last_values {
+            if let Some(last_values) = &mut self.cache_value_store {
                 let vec = last_values
                     .entry(node_id.to_owned())
                     .or_default()

--- a/runtime/src/flow_job/node_input_values.rs
+++ b/runtime/src/flow_job/node_input_values.rs
@@ -74,6 +74,23 @@ impl NodeInputValues {
         }
     }
 
+    pub fn update_cache_value(
+        &mut self,
+        node_id: &NodeId,
+        handle_name: &HandleName,
+        value: Arc<OutputValue>,
+    ) {
+        if let Some(last_values) = &mut self.cache_value_store {
+            let vec = last_values
+                .entry(node_id.to_owned())
+                .or_default()
+                .entry(handle_name.to_owned())
+                .or_default();
+            vec.clear();
+            vec.push_back(value);
+        }
+    }
+
     pub fn insert(&mut self, node_id: &NodeId, handle_name: &HandleName, value: Arc<OutputValue>) {
         self.store
             .entry(node_id.to_owned())

--- a/runtime/src/flow_job/node_input_values.rs
+++ b/runtime/src/flow_job/node_input_values.rs
@@ -151,7 +151,7 @@ impl NodeInputValues {
         0
     }
 
-    pub fn save_last_value(&self, path: PathBuf) -> Result<(), String> {
+    pub fn save_cache(&self, path: PathBuf) -> Result<(), String> {
         if let Some(last_values) = &self.last_values {
             // save hash map to file
             let json_string = serde_json::to_string(&last_values)

--- a/runtime/src/flow_job/node_input_values.rs
+++ b/runtime/src/flow_job/node_input_values.rs
@@ -81,21 +81,6 @@ impl NodeInputValues {
             .entry(handle_name.clone())
             .or_default()
             .push_back(Arc::clone(&value));
-
-        if !value.cacheable {
-            return;
-        }
-
-        if let Some(last_values) = &mut self.last_values {
-            // replace VecDeque with Var not push_back
-            let vec = last_values
-                .entry(node_id)
-                .or_default()
-                .entry(handle_name)
-                .or_default();
-            vec.clear();
-            vec.push_back(value);
-        }
     }
 
     pub fn is_node_fulfill(&self, node: &Node) -> bool {
@@ -248,6 +233,22 @@ impl NodeInputValues {
                     );
                 }
                 continue;
+            }
+        }
+
+        for (handle, value) in value_map.iter() {
+            if !value.cacheable {
+                continue;
+            }
+
+            if let Some(last_values) = &mut self.last_values {
+                let vec = last_values
+                    .entry(node_id.to_owned())
+                    .or_default()
+                    .entry(handle.to_owned())
+                    .or_default();
+                vec.clear();
+                vec.push_back(value.clone());
             }
         }
 

--- a/runtime/src/flow_job/node_input_values.rs
+++ b/runtime/src/flow_job/node_input_values.rs
@@ -258,15 +258,7 @@ impl NodeInputValues {
                 continue;
             }
 
-            if let Some(last_values) = &mut self.cache_value_store {
-                let vec = last_values
-                    .entry(node_id.to_owned())
-                    .or_default()
-                    .entry(handle.to_owned())
-                    .or_default();
-                vec.clear();
-                vec.push_back(value.clone());
-            }
+            self.update_cache_value(node_id, handle, Arc::clone(value));
         }
 
         if value_map.is_empty() {


### PR DESCRIPTION
```
<block1> -
          |
           —— <block2>.<input>.<a>
           —— <block2>.<input>.<b>
          |
<block3> - 
```

before this pull request, if block1 output three times with 1, 2, 3 and block3 output once with 1

block2 will cache with `{a: 3, b: 1}` but what we except is `{a: 1, b: 1}` which is what block2 execute.

after this pull request, cache value will be `{a: 1, b:1 }`.

and if user run with special nodes which not contain these node, these node's value will still update with new value.

---

- [x] ~~if run with special node, the downstream's value won't execute so it won't be update.~~