### PR TITLE
refactor: rename to _serialize_for_cache

### DIFF
--- a/manifest_meta/src/node/definition.rs
+++ b/manifest_meta/src/node/definition.rs
@@ -116,7 +116,7 @@ impl Node {
                     .as_mut()
                     .and_then(|def| def.get_mut(handle))
                 {
-                    output_def.__serialize_for_cache = true;
+                    output_def._serialize_for_cache = true;
                 }
                 task.task = Arc::new(task_inner);
             }
@@ -127,7 +127,7 @@ impl Node {
                     .as_mut()
                     .and_then(|def| def.get_mut(handle))
                 {
-                    output_def.__serialize_for_cache = true;
+                    output_def._serialize_for_cache = true;
                 }
                 flow.flow = Arc::new(flow_inner);
             }
@@ -138,7 +138,7 @@ impl Node {
                     .as_mut()
                     .and_then(|def| def.get_mut(handle))
                 {
-                    output_def.__serialize_for_cache = true;
+                    output_def._serialize_for_cache = true;
                 }
                 slot.slot = Arc::new(slot_inner);
             }
@@ -149,7 +149,7 @@ impl Node {
                     .as_mut()
                     .and_then(|def| def.get_mut(handle))
                 {
-                    output_def.__serialize_for_cache = true;
+                    output_def._serialize_for_cache = true;
                 }
                 service.block = Arc::new(service_inner);
             }

--- a/manifest_meta/tests/flow_test.rs
+++ b/manifest_meta/tests/flow_test.rs
@@ -216,7 +216,7 @@ mod tests {
                 .unwrap()
                 .get(&output_handle)
                 .unwrap();
-            assert!(output.__serialize_for_cache);
+            assert!(output._serialize_for_cache);
         }
     }
 

--- a/manifest_reader/src/manifest/block/handle.rs
+++ b/manifest_reader/src/manifest/block/handle.rs
@@ -156,9 +156,9 @@ pub struct OutputHandle {
     /// additional handle is not defined in block , it is defined in the flow node.
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub is_additional: bool,
-    /// This field is used to indicate whether the handle should be serialized for cache. This field is generated in runtime
+    /// This field is used to indicate whether the handle should be serialized for cache. Field with '_' prefix is generated in runtime
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
-    pub __serialize_for_cache: bool,
+    pub _serialize_for_cache: bool,
 }
 
 pub type InputHandles = HashMap<HandleName, InputHandle>;
@@ -198,7 +198,7 @@ mod tests {
             description: None,
             nullable: None,
             is_additional: false,
-            __serialize_for_cache: false,
+            _serialize_for_cache: false,
         };
         let serialized = serde_json::to_string(&output_handle).unwrap();
         assert_eq!(

--- a/manifest_reader/src/manifest/block/task.rs
+++ b/manifest_reader/src/manifest/block/task.rs
@@ -199,7 +199,7 @@ mod test {
                 kind: None,
                 nullable: None,
                 is_additional: false,
-                __serialize_for_cache: false,
+                _serialize_for_cache: false,
             })]),
             additional_inputs: true,
             additional_outputs: false,


### PR DESCRIPTION
use `_` prefix instead of `__` because it maybe effect python executor. Visit https://github.com/oomol/oocana-python/pull/408 to see the detail.