### PR TITLE
refactor: move serialize_for_cache to input_from field

### DIFF
--- a/manifest_meta/src/flow.rs
+++ b/manifest_meta/src/flow.rs
@@ -190,7 +190,10 @@ pub fn generate_node_inputs(
             inputs.insert(
                 handle.to_owned(),
                 NodeInput {
-                    def: input_def.clone(),
+                    def: InputHandle {
+                        _deserialize_from_cache: serialize_for_cache,
+                        ..input_def.clone()
+                    },
                     patch,
                     value,
                     sources: connection_from,

--- a/manifest_meta/src/flow.rs
+++ b/manifest_meta/src/flow.rs
@@ -179,6 +179,14 @@ pub fn generate_node_inputs(
                 }
             }
 
+            let serialize_for_cache = if let Some(node_inputs_from) = node_inputs_from {
+                node_inputs_from.iter().any(|input_from| {
+                    input_from.handle == *handle && input_from.serialize_for_cache
+                })
+            } else {
+                false
+            };
+
             inputs.insert(
                 handle.to_owned(),
                 NodeInput {
@@ -186,6 +194,7 @@ pub fn generate_node_inputs(
                     patch,
                     value,
                     sources: connection_from,
+                    serialize_for_cache,
                 },
             );
         }
@@ -536,6 +545,7 @@ impl SubflowBlock {
                                                         patch: None,
                                                         value: None,
                                                         sources: None, // from will be added later
+                                                        serialize_for_cache: false, // TODO: get serialize_for_cache from slotflow_provider.inputs_from
                                                     },
                                                 );
 
@@ -999,7 +1009,7 @@ impl SubflowBlock {
 
         for (_, node) in new_nodes.iter() {
             for (_, input) in node.inputs() {
-                if input.def.serialize_for_cache {
+                if input.serialize_for_cache {
                     if let Some(ref from) = input.sources {
                         for source in from.iter() {
                             match source {

--- a/manifest_meta/src/flow.rs
+++ b/manifest_meta/src/flow.rs
@@ -886,8 +886,6 @@ impl SubflowBlock {
                             task.inputs_def.clone()
                         };
 
-                    let inputs_def = merged_inputs_def.clone();
-
                     let inputs_def_patch = get_inputs_def_patch(&task_node.inputs_from);
 
                     let from = connections.node_inputs_froms.remove(&task_node.node_id);
@@ -910,21 +908,20 @@ impl SubflowBlock {
                             task.outputs_def.clone()
                         };
 
-                    let mut task_inner = (*task).clone();
-                    task_inner.outputs_def = merged_outputs_def;
-                    task_inner.inputs_def = merged_inputs_def;
-                    // TODO: this behavior change task's outputs_def, this task is a new task.
-                    //       maybe we should refactor this later.
-                    let task = Arc::new(task_inner);
-
                     let inputs = generate_node_inputs(
-                        &inputs_def,
+                        &merged_inputs_def,
                         &from,
                         &task_node.inputs_from,
                         &inputs_def_patch,
                         &task_node.node_id,
                     );
 
+                    let mut task_inner = (*task).clone();
+                    task_inner.outputs_def = merged_outputs_def;
+                    task_inner.inputs_def = merged_inputs_def.clone();
+                    // TODO: this behavior change task's outputs_def, this task is a new task.
+                    //       maybe we should refactor this later.
+                    let task = Arc::new(task_inner);
                     new_nodes.insert(
                         task_node.node_id.to_owned(),
                         Node::Task(TaskNode {

--- a/manifest_meta/src/flow.rs
+++ b/manifest_meta/src/flow.rs
@@ -548,7 +548,16 @@ impl SubflowBlock {
                                                         patch: None,
                                                         value: None,
                                                         sources: None, // from will be added later
-                                                        serialize_for_cache: false, // TODO: get serialize_for_cache from slotflow_provider.inputs_from
+                                                        serialize_for_cache: slotflow_provider
+                                                            .inputs_from
+                                                            .as_ref()
+                                                            .and_then(|inputs_from| {
+                                                                inputs_from
+                                                                    .iter()
+                                                                    .find(|i| i.handle == input.handle)
+                                                                    .map(|i| i.serialize_for_cache)
+                                                            })
+                                                            .unwrap_or(false),
                                                     },
                                                 );
 

--- a/manifest_meta/src/flow.rs
+++ b/manifest_meta/src/flow.rs
@@ -185,7 +185,7 @@ pub fn generate_node_inputs(
                     def: input_def.clone(),
                     patch,
                     value,
-                    from: connection_from,
+                    sources: connection_from,
                 },
             );
         }
@@ -227,7 +227,7 @@ impl SubflowBlock {
         let mut inputs: HashMap<NodeId, Vec<InputHandle>> = HashMap::new();
         for (node_id, node) in &self.nodes {
             for input in node.inputs().values() {
-                if input.from.as_ref().is_some_and(|f| !f.is_empty()) {
+                if input.sources.as_ref().is_some_and(|f| !f.is_empty()) {
                     continue; // skip if input has connection
                 }
 
@@ -535,7 +535,7 @@ impl SubflowBlock {
                                                         },
                                                         patch: None,
                                                         value: None,
-                                                        from: None, // from will be added later
+                                                        sources: None, // from will be added later
                                                     },
                                                 );
 
@@ -579,7 +579,7 @@ impl SubflowBlock {
                                                             .entry(input.handle.clone())
                                                             .and_modify(|node_input| {
                                                                 node_input
-                                                                    .from
+                                                                    .sources
                                                                     .get_or_insert_with(Vec::new)
                                                                     .push(
                                                                         crate::node::HandleSource::FlowInput {
@@ -1000,7 +1000,7 @@ impl SubflowBlock {
         for (_, node) in new_nodes.iter() {
             for (_, input) in node.inputs() {
                 if input.def.serialize_for_cache {
-                    if let Some(ref from) = input.from {
+                    if let Some(ref from) = input.sources {
                         for source in from.iter() {
                             match source {
                                 crate::node::HandleSource::FlowInput { .. } => {

--- a/manifest_meta/src/node/common.rs
+++ b/manifest_meta/src/node/common.rs
@@ -9,8 +9,10 @@ use manifest_reader::{
 pub struct NodeInput {
     pub def: InputHandle,
     pub patch: Option<Vec<InputDefPatch>>,
+    // generate from node's from.value or from value_node
     pub value: Option<Option<JsonValue>>,
-    pub from: Option<Vec<HandleSource>>,
+    // generate from node's from.flow_input or from node's from.node_output
+    pub sources: Option<Vec<HandleSource>>,
 }
 
 #[macro_export(local_inner_macros)]

--- a/manifest_meta/src/node/common.rs
+++ b/manifest_meta/src/node/common.rs
@@ -13,6 +13,7 @@ pub struct NodeInput {
     pub value: Option<Option<JsonValue>>,
     // generate from node's from.flow_input or from node's from.node_output
     pub sources: Option<Vec<HandleSource>>,
+    pub serialize_for_cache: bool,
 }
 
 #[macro_export(local_inner_macros)]

--- a/manifest_meta/src/node/definition.rs
+++ b/manifest_meta/src/node/definition.rs
@@ -184,7 +184,7 @@ impl Node {
     pub fn has_connection(&self, handle: &HandleName) -> bool {
         self.inputs()
             .get(handle)
-            .is_some_and(|input| input.from.as_ref().is_some_and(|f| !f.is_empty()))
+            .is_some_and(|input| input.sources.as_ref().is_some_and(|f| !f.is_empty()))
     }
 
     pub fn package_path(&self) -> Option<PathBuf> {

--- a/manifest_meta/tests/flow_test.rs
+++ b/manifest_meta/tests/flow_test.rs
@@ -218,6 +218,21 @@ mod tests {
                 .unwrap();
             assert!(output._serialize_for_cache);
         }
+
+        let node2_id = NodeId::new("node2".to_owned());
+        let node2 = flow_block.nodes.get(&node2_id).unwrap();
+        assert!(matches!(node2, manifest_meta::Node::Task(_)));
+        if let manifest_meta::Node::Task(task_node) = node2 {
+            let input_handle = HandleName::new("in".to_owned());
+            let input = task_node
+                .task
+                .inputs_def
+                .as_ref()
+                .unwrap()
+                .get(&input_handle)
+                .unwrap();
+            assert!(input._deserialize_from_cache);
+        }
     }
 
     fn test_directory() -> PathBuf {

--- a/manifest_meta/tests/flow_test.rs
+++ b/manifest_meta/tests/flow_test.rs
@@ -64,7 +64,7 @@ mod tests {
                 .inputs
                 .get(&handle_in1)
                 .unwrap()
-                .from
+                .sources
                 .as_ref()
                 .unwrap()
                 .first()
@@ -121,13 +121,13 @@ mod tests {
                 .is_some_and(|schema| { schema.get("type").is_some_and(|t| t == "string") }));
 
             assert!(matches!(
-                input_in1.from.as_ref().unwrap().first().unwrap(),
+                input_in1.sources.as_ref().unwrap().first().unwrap(),
                 manifest_meta::HandleSource::NodeOutput { .. }
             ));
             if let manifest_meta::HandleSource::NodeOutput {
                 node_id,
                 output_handle,
-            } = input_in1.from.as_ref().unwrap().first().unwrap()
+            } = input_in1.sources.as_ref().unwrap().first().unwrap()
             {
                 assert_eq!(node_id, &node1_id);
                 assert_eq!(output_handle, &handle_out2);

--- a/manifest_meta/tests/flow_test/serializable-var/block2.oo.yaml
+++ b/manifest_meta/tests/flow_test/serializable-var/block2.oo.yaml
@@ -6,4 +6,3 @@ inputs_def:
     json_schema:
       type: string
       contentMediaType: oomol/var
-    serialize_for_cache: true

--- a/manifest_meta/tests/flow_test/serializable-var/subflow.oo.yaml
+++ b/manifest_meta/tests/flow_test/serializable-var/subflow.oo.yaml
@@ -5,6 +5,7 @@ nodes:
     task: "./block2.oo.yaml"
     inputs_from:
       - handle: in
+        serialize_for_cache: true
         from_node:
           - node_id: node1
             output_handle: out

--- a/manifest_reader/src/manifest/block/handle.rs
+++ b/manifest_reader/src/manifest/block/handle.rs
@@ -55,8 +55,6 @@ struct TempInputHandle {
         with = "::serde_with::rust::double_option"
     )]
     pub value: Option<Option<serde_json::Value>>,
-    #[serde(skip_serializing_if = "std::ops::Not::not", default)]
-    pub serialize_for_cache: bool,
 }
 
 impl From<TempInputHandle> for InputHandle {
@@ -68,7 +66,6 @@ impl From<TempInputHandle> for InputHandle {
             kind,
             nullable,
             value,
-            serialize_for_cache,
         } = temp;
         let value = if temp.nullable.is_some_and(|nullable| nullable) {
             if value.is_none() {
@@ -88,7 +85,7 @@ impl From<TempInputHandle> for InputHandle {
             value,
             remember: false,
             is_additional: false,
-            serialize_for_cache,
+            _deserialize_from_cache: false,
         }
     }
 }
@@ -117,8 +114,9 @@ pub struct InputHandle {
     /// Additional handles are defined in the flow node, not in the block.
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub is_additional: bool,
+    /// This field is used to indicate whether the handle should be deserialized from cache. '_' prefix means this field is generated in runtime
     #[serde(skip_serializing_if = "std::ops::Not::not")]
-    pub serialize_for_cache: bool,
+    pub _deserialize_from_cache: bool,
 }
 
 impl InputHandle {
@@ -132,7 +130,7 @@ impl InputHandle {
             nullable: None,
             remember: false,
             is_additional: false,
-            serialize_for_cache: false,
+            _deserialize_from_cache: false,
         }
     }
 }

--- a/manifest_reader/src/manifest/block/task.rs
+++ b/manifest_reader/src/manifest/block/task.rs
@@ -186,7 +186,7 @@ mod test {
                     value: None,
                     remember: false,
                     is_additional: false,
-                    serialize_for_cache: false,
+                    _deserialize_from_cache: false,
                 }),
                 MiddleInputHandle::Group {
                     group: "section".to_string(),

--- a/manifest_reader/src/manifest/node/input_from.rs
+++ b/manifest_reader/src/manifest/node/input_from.rs
@@ -30,8 +30,7 @@ struct TmpNodeInputFrom {
     pub schema_overrides: Option<Vec<TmpInputDefPatch>>,
     pub from_flow: Option<Vec<FlowHandleFrom>>,
     pub from_node: Option<Vec<NodeHandleFrom>>,
-    /// Indicates whether the input should be serialized for caching purposes.
-    /// Set this to `true` if the input needs to be stored in a cache for reuse.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub serialize_for_cache: bool,
 }
 
@@ -80,6 +79,8 @@ pub struct NodeInputFrom {
 
     pub from_flow: Option<Vec<FlowHandleFrom>>,
     pub from_node: Option<Vec<NodeHandleFrom>>,
+    /// Indicates whether the input should be serialized for caching purposes (implemented in executor)
+    /// Set this to `true` if the input needs to be stored in a cache for reuse. Currently, this is only used for Python Pandas DataFrame inputs.
     pub serialize_for_cache: bool,
 }
 

--- a/manifest_reader/src/manifest/node/input_from.rs
+++ b/manifest_reader/src/manifest/node/input_from.rs
@@ -30,6 +30,8 @@ struct TmpNodeInputFrom {
     pub schema_overrides: Option<Vec<TmpInputDefPatch>>,
     pub from_flow: Option<Vec<FlowHandleFrom>>,
     pub from_node: Option<Vec<NodeHandleFrom>>,
+    /// Indicates whether the input should be serialized for caching purposes.
+    /// Set this to `true` if the input needs to be stored in a cache for reuse.
     pub serialize_for_cache: bool,
 }
 

--- a/manifest_reader/src/manifest/node/input_from.rs
+++ b/manifest_reader/src/manifest/node/input_from.rs
@@ -30,6 +30,7 @@ struct TmpNodeInputFrom {
     pub schema_overrides: Option<Vec<TmpInputDefPatch>>,
     pub from_flow: Option<Vec<FlowHandleFrom>>,
     pub from_node: Option<Vec<NodeHandleFrom>>,
+    pub serialize_for_cache: bool,
 }
 
 /// PatchSchema
@@ -77,6 +78,7 @@ pub struct NodeInputFrom {
 
     pub from_flow: Option<Vec<FlowHandleFrom>>,
     pub from_node: Option<Vec<NodeHandleFrom>>,
+    pub serialize_for_cache: bool,
 }
 
 impl From<TmpNodeInputFrom> for NodeInputFrom {
@@ -110,11 +112,12 @@ impl From<TmpNodeInputFrom> for NodeInputFrom {
         };
 
         NodeInputFrom {
+            schema_overrides,
             handle: data.handle,
             value: data.value,
-            schema_overrides,
             from_flow: data.from_flow,
             from_node: data.from_node,
+            serialize_for_cache: data.serialize_for_cache,
         }
     }
 }

--- a/runtime/src/flow_job/node_input_values.rs
+++ b/runtime/src/flow_job/node_input_values.rs
@@ -125,7 +125,7 @@ impl NodeInputValues {
 
     pub fn is_node_fulfill(&self, node: &Node) -> bool {
         for (handle, input) in node.inputs() {
-            if input.from.as_ref().is_none_or(|f| f.is_empty()) && input.value.is_some() {
+            if input.sources.as_ref().is_none_or(|f| f.is_empty()) && input.value.is_some() {
                 continue;
             }
 
@@ -149,7 +149,7 @@ impl NodeInputValues {
 
     pub fn node_has_input(&self, node: &Node, handle_name: &HandleName) -> bool {
         if let Some(input) = node.inputs().get(handle_name) {
-            if input.from.as_ref().is_none_or(|f| f.is_empty()) && input.value.is_some() {
+            if input.sources.as_ref().is_none_or(|f| f.is_empty()) && input.value.is_some() {
                 return true;
             }
         }
@@ -198,7 +198,7 @@ impl NodeInputValues {
     pub fn remove_input_values(&mut self, node: &Node, from_nodes: &HashSet<NodeId>) {
         if let Some(inputs_map) = self.store.get_mut(node.node_id()) {
             for (handle, node_input) in node.inputs() {
-                for from in node_input.from.iter().flatten() {
+                for from in node_input.sources.iter().flatten() {
                     if let manifest_meta::HandleSource::NodeOutput { node_id, .. } = from {
                         if from_nodes.contains(node_id) {
                             inputs_map.remove(handle);
@@ -258,7 +258,7 @@ impl NodeInputValues {
         }
 
         for (handle, input) in node.inputs() {
-            if input.from.as_ref().is_none_or(|f| f.is_empty()) {
+            if input.sources.as_ref().is_none_or(|f| f.is_empty()) {
                 if let Some(value) = input.value.as_ref() {
                     value_map.insert(
                         handle.to_owned(),

--- a/runtime/src/flow_job/run_to_node.rs
+++ b/runtime/src/flow_job/run_to_node.rs
@@ -66,7 +66,7 @@ fn calc_node_deps(
             continue;
         }
 
-        for node_source in input.from.iter().flatten() {
+        for node_source in input.sources.iter().flatten() {
             if let manifest_meta::HandleSource::NodeOutput { node_id, .. } = node_source {
                 if !should_run_nodes.contains(node_id) {
                     if let Some(dependent_node) = flow.nodes.get(node_id) {


### PR DESCRIPTION
- **refactor: rename to _serialize_for_cache**
- **refactor: rename to sources**
- **refactor: move serialize_for_cache to node input from**
- **feat: add _deserialize_from_cache generate field for input def**
- **refactor: avoid reassign**
- **update runtime field**
