### PR TITLE
refactor: path finder

### DIFF
--- a/manifest_reader/src/path_finder/flow.rs
+++ b/manifest_reader/src/path_finder/flow.rs
@@ -5,7 +5,7 @@ use utils::error::Result;
 use super::manifest_file::find_oo_yaml;
 
 pub fn find_flow<P: AsRef<Path>>(flow_path: P) -> Result<PathBuf> {
-    match find_oo_yaml(flow_path.as_ref(), "flow") {
+    match find_oo_yaml(&flow_path, "flow") {
         Some(path) => Ok(path.clean()),
         None => Err(utils::error::Error::new(&format!(
             "Flow {:?} not found",

--- a/manifest_reader/src/path_finder/manifest_file.rs
+++ b/manifest_reader/src/path_finder/manifest_file.rs
@@ -9,18 +9,16 @@ pub fn find_oo_yaml_in_dir<P: AsRef<Path>>(dir_path: P, basename: &str) -> Optio
     }
 }
 
-//  find `<basename_path>.oo.yaml` or `<basename_path>.oo.yml` file, return the existing path or None.
+//  find `</a/b/c/basename_path>.oo.yaml` or `</a/b/c/basename_path>.oo.yml` file, return the existing path or None.
 pub fn find_oo_yaml_without_oo_suffix<P: AsRef<Path>>(
     path_without_oo_suffix: P,
 ) -> Option<PathBuf> {
     let mut guess_file_path = path_without_oo_suffix.as_ref().with_extension("oo.yaml");
-
     if guess_file_path.is_file() {
         return Some(guess_file_path);
     }
 
     guess_file_path.set_extension("yml");
-
     if guess_file_path.is_file() {
         return Some(guess_file_path);
     }

--- a/manifest_reader/src/path_finder/manifest_file.rs
+++ b/manifest_reader/src/path_finder/manifest_file.rs
@@ -1,9 +1,9 @@
 use std::path::{Path, PathBuf};
 
 /// find `<basename>.oo.yaml` or `<basename>.oo.yml` file in <dir_path>, return the existing path or None.
-pub fn find_oo_yaml_in_dir(dir_path: &Path, basename: &str) -> Option<PathBuf> {
-    if dir_path.is_dir() {
-        let mut guess_file = dir_path.join(format!("{}.oo.yaml", basename));
+pub fn find_oo_yaml_in_dir<P: AsRef<Path>>(dir_path: P, basename: &str) -> Option<PathBuf> {
+    if dir_path.as_ref().is_dir() {
+        let mut guess_file = dir_path.as_ref().join(format!("{}.oo.yaml", basename));
         if guess_file.is_file() {
             return Some(guess_file);
         }
@@ -17,9 +17,11 @@ pub fn find_oo_yaml_in_dir(dir_path: &Path, basename: &str) -> Option<PathBuf> {
     None
 }
 
-/// Find `<basename_path>.oo.yaml` or `<basename_path>.oo.yml` file, return the existing path or None.
-pub fn find_oo_yaml_without_suffix(basename_path: &Path) -> Option<PathBuf> {
-    let mut guess_file_path = basename_path.with_extension("oo.yaml");
+//  find `<basename_path>.oo.yaml` or `<basename_path>.oo.yml` file, return the existing path or None.
+pub fn find_oo_yaml_without_oo_suffix<P: AsRef<Path>>(
+    path_without_oo_suffix: P,
+) -> Option<PathBuf> {
+    let mut guess_file_path = path_without_oo_suffix.as_ref().with_extension("oo.yaml");
 
     if guess_file_path.is_file() {
         return Some(guess_file_path);

--- a/manifest_reader/src/path_finder/manifest_file.rs
+++ b/manifest_reader/src/path_finder/manifest_file.rs
@@ -9,7 +9,7 @@ pub fn find_oo_yaml_in_dir<P: AsRef<Path>>(dir_path: P, basename: &str) -> Optio
     }
 }
 
-//  find `</a/b/c/basename_path>.oo.yaml` or `</a/b/c/basename_path>.oo.yml` file, return the existing path or None.
+/// find `</a/b/c/basename_path>.oo.yaml` or `</a/b/c/basename_path>.oo.yml` file, return the existing path or None.
 pub fn find_oo_yaml_without_oo_suffix<P: AsRef<Path>>(
     path_without_oo_suffix: P,
 ) -> Option<PathBuf> {

--- a/manifest_reader/src/path_finder/manifest_file.rs
+++ b/manifest_reader/src/path_finder/manifest_file.rs
@@ -3,18 +3,10 @@ use std::path::{Path, PathBuf};
 /// find `<basename>.oo.yaml` or `<basename>.oo.yml` file in <dir_path>, return the existing path or None.
 pub fn find_oo_yaml_in_dir<P: AsRef<Path>>(dir_path: P, basename: &str) -> Option<PathBuf> {
     if dir_path.as_ref().is_dir() {
-        let mut guess_file = dir_path.as_ref().join(format!("{}.oo.yaml", basename));
-        if guess_file.is_file() {
-            return Some(guess_file);
-        }
-
-        guess_file.set_extension("yml");
-        if guess_file.is_file() {
-            return Some(guess_file);
-        }
+        find_oo_yaml_without_oo_suffix(dir_path.as_ref().join(basename))
+    } else {
+        None
     }
-
-    None
 }
 
 //  find `<basename_path>.oo.yaml` or `<basename_path>.oo.yml` file, return the existing path or None.

--- a/manifest_reader/src/path_finder/search_paths.rs
+++ b/manifest_reader/src/path_finder/search_paths.rs
@@ -1,6 +1,6 @@
 use tracing::warn;
 
-use super::manifest_file::{find_oo_yaml, find_oo_yaml_in_dir, find_oo_yaml_without_suffix};
+use super::manifest_file::{find_oo_yaml, find_oo_yaml_in_dir, find_oo_yaml_without_oo_suffix};
 use std::collections::HashMap;
 use std::fs::canonicalize;
 use std::path::{Component, Path, PathBuf};
@@ -54,7 +54,10 @@ pub fn search_block_manifest(params: BlockManifestParams) -> Option<PathBuf> {
                     .iter()
                     .collect()
             } else {
-                warn!("can't find package version for {}. pkg directory will use {} without version", pkg_name, pkg_name);
+                warn!(
+                    "can't find package version for {}. pkg directory will use {} without version",
+                    pkg_name, pkg_name
+                );
                 [&pkg_name, block_dir, &block_name].iter().collect()
             };
             find_block_manifest_file(BlockSearchParams {
@@ -73,7 +76,7 @@ pub fn search_block_manifest(params: BlockManifestParams) -> Option<PathBuf> {
     }
 }
 
-// parse <pkg>::<block> or <pkg>::<service>::<function> and return an Option<(String, String)>, 
+// parse <pkg>::<block> or <pkg>::<service>::<function> and return an Option<(String, String)>,
 // where the first element is the package name (pkg) and the second is the block or service name.
 fn separate_to_pkg_and_block(block_value: &str) -> Option<(String, String)> {
     let parts: Vec<&str> = block_value.split("::").filter(|s| !s.is_empty()).collect();
@@ -192,7 +195,7 @@ fn find_manifest_yaml_file(file_or_dir_path: &Path, base_name: &str) -> Option<P
         return result;
     }
 
-    find_oo_yaml_without_suffix(file_or_dir_path)
+    find_oo_yaml_without_oo_suffix(file_or_dir_path)
 }
 
 fn is_normal_path_component(component: Component) -> bool {


### PR DESCRIPTION
1. use as_ref generic instead of Path
2. rename function name
3. merge same logic to one function

no break change, no logic change.