### PR TITLE
refactor!: more strict find logic

### DIFF
--- a/manifest_meta/src/lib.rs
+++ b/manifest_meta/src/lib.rs
@@ -48,17 +48,6 @@ pub fn read_flow_or_block(
     mut block_reader: BlockResolver,
     mut path_finder: BlockPathFinder,
 ) -> Result<Block> {
-    // TODO: Remove this check when the block reader is fully implemented
-    if block_name.ends_with("block.oo.yaml")
-        || block_name.ends_with("block.oo.yml")
-        || block_name.ends_with("task.oo.yaml")
-        || block_name.ends_with("task.oo.yml")
-    {
-        return block_reader
-            .read_task_block(std::path::Path::new(block_name))
-            .map(Block::Task);
-    }
-
     if let Ok(flow_path) = find_flow(block_name) {
         return flow_resolver::read_flow(&flow_path, &mut block_reader, &mut path_finder)
             .map(|flow| Block::Flow(Arc::new(flow)));

--- a/manifest_reader/src/path_finder/block.rs
+++ b/manifest_reader/src/path_finder/block.rs
@@ -26,7 +26,7 @@ pub fn find_task_block(params: TaskBlockManifestParams) -> Result<PathBuf> {
     } = params;
     if let Some(path) = search_block_manifest(BlockManifestParams {
         block_value: calculate_block_value_type(value),
-        base_name: "block",
+        file_prefix: "block",
         block_dir: "blocks",
         working_dir: base_dir,
         search_paths,
@@ -37,7 +37,7 @@ pub fn find_task_block(params: TaskBlockManifestParams) -> Result<PathBuf> {
 
     if let Some(path) = search_block_manifest(BlockManifestParams {
         block_value: calculate_block_value_type(value),
-        base_name: "task",
+        file_prefix: "task",
         block_dir: "tasks",
         working_dir: base_dir,
         search_paths,
@@ -74,7 +74,7 @@ pub fn find_flow_block(params: SubflowBlockManifestParams) -> Result<PathBuf> {
     } = params;
     match search_block_manifest(BlockManifestParams {
         block_value: calculate_block_value_type(value),
-        base_name: "subflow",
+        file_prefix: "subflow",
         block_dir: "subflows",
         working_dir: base_dir,
         search_paths,
@@ -120,7 +120,7 @@ pub fn find_slot_flow(params: SlotBlockManifestParams) -> Result<PathBuf> {
 
     match search_block_manifest(BlockManifestParams {
         block_value: calculate_block_value_type(value),
-        base_name: "slotflow",
+        file_prefix: "slotflow",
         block_dir: "slotflows",
         working_dir: base_dir,
         search_paths,

--- a/manifest_reader/src/path_finder/manifest_file.rs
+++ b/manifest_reader/src/path_finder/manifest_file.rs
@@ -26,11 +26,23 @@ pub fn find_oo_yaml_without_oo_suffix<P: AsRef<Path>>(
     None
 }
 
-pub fn find_oo_yaml<P: AsRef<Path>>(file_or_dir_path: P, basename: &str) -> Option<PathBuf> {
-    if file_or_dir_path.as_ref().is_file() {
-        Some(file_or_dir_path.as_ref().to_path_buf())
+/// if path is a dir, find `<basename>.oo.yaml` or `<basename>.oo.yml` file in the dir.
+/// if path is a file, check if it is `<basename>.oo.yaml` or `<basename>.oo.yml`.
+/// if path is neither, return None.
+pub fn find_oo_yaml<P: AsRef<Path>>(path: P, basename: &str) -> Option<PathBuf> {
+    let path = path.as_ref();
+    if path.is_dir() {
+        return find_oo_yaml_in_dir(path, basename);
+    } else if path.is_file() {
+        let filename = path.file_name();
+        if let Some(name) = filename.and_then(|n| n.to_str()) {
+            if name == format!("{basename}.oo.yaml") || name == format!("{basename}.oo.yml") {
+                return Some(path.to_path_buf());
+            }
+        }
+        return None;
     } else {
-        find_oo_yaml_in_dir(file_or_dir_path.as_ref(), basename)
+        return None;
     }
 }
 

--- a/manifest_reader/src/path_finder/manifest_file.rs
+++ b/manifest_reader/src/path_finder/manifest_file.rs
@@ -1,9 +1,9 @@
 use std::path::{Path, PathBuf};
 
-/// find `<basename>.oo.yaml` or `<basename>.oo.yml` file in <dir_path>, return the existing path or None.
-pub fn find_oo_yaml_in_dir<P: AsRef<Path>>(dir_path: P, basename: &str) -> Option<PathBuf> {
+/// find `<file_prefix>.oo.yaml` or `<file_prefix>.oo.yml` file in <dir_path>, return the existing path or None.
+pub fn find_oo_yaml_in_dir<P: AsRef<Path>>(dir_path: P, file_prefix: &str) -> Option<PathBuf> {
     if dir_path.as_ref().is_dir() {
-        find_oo_yaml_without_oo_suffix(dir_path.as_ref().join(basename))
+        find_oo_yaml_without_oo_suffix(dir_path.as_ref().join(file_prefix))
     } else {
         None
     }
@@ -26,17 +26,17 @@ pub fn find_oo_yaml_without_oo_suffix<P: AsRef<Path>>(
     None
 }
 
-/// if path is a dir, find `<basename>.oo.yaml` or `<basename>.oo.yml` file in the dir.
-/// if path is a file, check if it is `<basename>.oo.yaml` or `<basename>.oo.yml`.
+/// if path is a dir, find `<file_prefix>.oo.yaml` or `<file_prefix>.oo.yml` file in the dir.
+/// if path is a file, check if it is `<file_prefix>.oo.yaml` or `<file_prefix>.oo.yml`.
 /// if path is neither, return None.
-pub fn find_oo_yaml<P: AsRef<Path>>(path: P, basename: &str) -> Option<PathBuf> {
+pub fn find_oo_yaml<P: AsRef<Path>>(path: P, file_prefix: &str) -> Option<PathBuf> {
     let path = path.as_ref();
     if path.is_dir() {
-        return find_oo_yaml_in_dir(path, basename);
+        return find_oo_yaml_in_dir(path, file_prefix);
     } else if path.is_file() {
         let filename = path.file_name();
         if let Some(name) = filename.and_then(|n| n.to_str()) {
-            if name == format!("{basename}.oo.yaml") || name == format!("{basename}.oo.yml") {
+            if name == format!("{file_prefix}.oo.yaml") || name == format!("{file_prefix}.oo.yml") {
                 return Some(path.to_path_buf());
             }
         }

--- a/manifest_reader/src/path_finder/search_paths.rs
+++ b/manifest_reader/src/path_finder/search_paths.rs
@@ -7,7 +7,7 @@ use std::path::{Component, Path, PathBuf};
 
 pub struct BlockManifestParams<'a> {
     pub block_value: BlockValueType,
-    pub base_name: &'a str,
+    pub file_prefix: &'a str,
     pub block_dir: &'a str,
     pub search_paths: &'a [PathBuf],
     pub working_dir: &'a Path,
@@ -15,11 +15,11 @@ pub struct BlockManifestParams<'a> {
 }
 
 /// TODO: better return error with block type and search path instead of Option, so that we can reporter more specific error.
-/// search block manifest in <block_dir>/<block_name>/<base_name>.oo.[yaml|yml] in working_dir or search_paths.
+/// search block manifest in <block_dir>/<block_name>/<file_prefix>.oo.[yaml|yml] in working_dir or search_paths.
 pub fn search_block_manifest(params: BlockManifestParams) -> Option<PathBuf> {
     let BlockManifestParams {
         block_value: value,
-        base_name,
+        file_prefix,
         block_dir,
         search_paths,
         working_dir,
@@ -33,12 +33,12 @@ pub fn search_block_manifest(params: BlockManifestParams) -> Option<PathBuf> {
             self_manifest_path.pop();
             self_manifest_path.push(block_dir);
             self_manifest_path.push(block_name);
-            find_manifest_yaml_file(&self_manifest_path, base_name)
+            find_manifest_yaml_file(&self_manifest_path, file_prefix)
         }
         BlockValueType::Direct { path: block_path } => {
             find_block_manifest_file(BlockSearchParams {
                 manifest_path: &PathBuf::from(block_path),
-                base_name,
+                file_prefix,
                 flow_dir: working_dir,
                 search_paths,
                 manifest_maybe_file: true,
@@ -62,16 +62,16 @@ pub fn search_block_manifest(params: BlockManifestParams) -> Option<PathBuf> {
             };
             find_block_manifest_file(BlockSearchParams {
                 manifest_path: &manifest_path,
-                base_name,
+                file_prefix,
                 flow_dir: working_dir,
                 search_paths,
                 manifest_maybe_file: false,
             })
         }
-        BlockValueType::AbsPath { path } => find_manifest_yaml_file(path.as_ref(), base_name),
+        BlockValueType::AbsPath { path } => find_manifest_yaml_file(path.as_ref(), file_prefix),
         BlockValueType::RelPath { path } => {
             let block_manifest_path = working_dir.join(path);
-            find_manifest_yaml_file(&block_manifest_path, base_name)
+            find_manifest_yaml_file(&block_manifest_path, file_prefix)
         }
     }
 }
@@ -153,17 +153,17 @@ pub fn calculate_block_value_type(block_value: &str) -> BlockValueType {
 
 struct BlockSearchParams<'a> {
     pub manifest_path: &'a Path, // block directory path, like <pkg_name>/<block_type+'s'><block_name> or <block_name>
-    pub base_name: &'a str, // base_name is the name of the manifest without the suffix (oo.yaml, oo.yml)
+    pub file_prefix: &'a str, // file_prefix is the name of the manifest without the suffix (oo.yaml, oo.yml)
     pub flow_dir: &'a Path, // flow directory, oocana will treat flow dir as the pkg_dir. otherwise, oocana will treat flow_dir as the last search path.
     pub search_paths: &'a [PathBuf], // search paths for pkg_dir.
     pub manifest_maybe_file: bool, // if false, manifest is must be a directory.
 }
 
-// find <manifest_path>/<base_name>.oo.yaml in search_paths or flow_dir.
+// find <manifest_path>/<file_prefix>.oo.yaml in search_paths or flow_dir.
 fn find_block_manifest_file(params: BlockSearchParams) -> Option<PathBuf> {
     let BlockSearchParams {
         manifest_path,
-        base_name,
+        file_prefix,
         flow_dir,
         search_paths,
         manifest_maybe_file,
@@ -171,7 +171,7 @@ fn find_block_manifest_file(params: BlockSearchParams) -> Option<PathBuf> {
 
     for search_path in search_paths.iter() {
         let candidate_path = search_path.join(manifest_path);
-        let file_path = find_oo_yaml_in_dir(&candidate_path, base_name);
+        let file_path = find_oo_yaml_in_dir(&candidate_path, file_prefix);
         if let Some(path) = file_path {
             return canonicalize(&path).ok();
         }
@@ -179,9 +179,9 @@ fn find_block_manifest_file(params: BlockSearchParams) -> Option<PathBuf> {
 
     let candidate_path = flow_dir.join(manifest_path);
     let p = if manifest_maybe_file {
-        find_oo_yaml(&candidate_path, base_name)
+        find_oo_yaml(&candidate_path, file_prefix)
     } else {
-        find_oo_yaml_in_dir(&candidate_path, base_name)
+        find_oo_yaml_in_dir(&candidate_path, file_prefix)
     };
     match p {
         Some(path) => canonicalize(&path).ok(),
@@ -189,8 +189,8 @@ fn find_block_manifest_file(params: BlockSearchParams) -> Option<PathBuf> {
     }
 }
 
-fn find_manifest_yaml_file(file_or_dir_path: &Path, base_name: &str) -> Option<PathBuf> {
-    let result = find_oo_yaml(file_or_dir_path, base_name);
+fn find_manifest_yaml_file(file_or_dir_path: &Path, file_prefix: &str) -> Option<PathBuf> {
+    let result = find_oo_yaml(file_or_dir_path, file_prefix);
     if result.is_some() {
         return result;
     }

--- a/manifest_reader/src/path_finder/service.rs
+++ b/manifest_reader/src/path_finder/service.rs
@@ -26,7 +26,7 @@ pub fn find_service(params: ServiceManifestParams) -> Result<PathBuf> {
     } = params;
     if let Some(path) = search_block_manifest(BlockManifestParams {
         block_value: calculate_block_value_type(value),
-        base_name: "service",
+        file_prefix: "service",
         block_dir: "services",
         working_dir: base_dir,
         search_paths: block_search_paths,
@@ -37,7 +37,7 @@ pub fn find_service(params: ServiceManifestParams) -> Result<PathBuf> {
 
     if let Some(path) = search_block_manifest(BlockManifestParams {
         block_value: calculate_block_value_type(value),
-        base_name: "service",
+        file_prefix: "service",
         block_dir: "blocks",
         working_dir: base_dir,
         search_paths: block_search_paths,


### PR DESCRIPTION
1. remove read block workaround
2. manifest search will require fixed suffix(`oo.yaml` or `oo.yml`)
3. **now only relative path support arbitrarily file, but it still require fixed suffix**
4. use better arg name to distinguish