### PR TITLE
feat: remove npm bin field

### DIFF
--- a/npm/npm.mjs
+++ b/npm/npm.mjs
@@ -54,9 +54,6 @@ for (const target of targets) {
         name: `@${owner}/oocana-cli-${target}`,
         description: `The ${target} cli binary for @${owner}/oocana`,
         version,
-        bin: {
-            "oocana": `bin/oocana`,
-        },
         os: targetConfig[target].os,
         cpu: targetConfig[target].cpu,
         ...packageTemplate,

--- a/npm/target.mjs
+++ b/npm/target.mjs
@@ -1,8 +1,10 @@
 export const packageTemplate = {
-    "preferUnplugged": true,
     "engines": {
-        "node": ">=12"
+        "node": ">=22"
     },
+    "files": [
+        "bin"
+    ],
     "publishConfig": {
         "registry": "https://npm.pkg.github.com"
     }


### PR DESCRIPTION
multiple `optionalDependencies` packages have same bin name will make npm fail to link success downloaded one to `node_modules/.bin`