### PR TITLE
fix: some npm version download failed when only files

### DIFF
--- a/npm/target.mjs
+++ b/npm/target.mjs
@@ -5,6 +5,7 @@ export const packageTemplate = {
     "files": [
         "bin", "index.js"
     ],
+    "main": "index.js",
     "publishConfig": {
         "registry": "https://npm.pkg.github.com"
     }


### PR DESCRIPTION
```
  node: v20.19.4
  npm: 10.8.2
  yarn: 1.22.22
```

will fail to download current npm package