### PR TITLE
feat: add vault

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3556,12 +3556,12 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 name = "vault"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "reqwest 0.11.27",
  "serde",
  "serde_json",
  "tokio",
  "tracing",
+ "utils",
  "wiremock",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,6 +121,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "assert_cmd"
 version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -148,12 +158,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
  "winapi",
 ]
@@ -621,6 +637,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "deadpool"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb84100978c1c7b37f09ed3ce3e5f843af02c2a2c431bae5b19230dad2c1b490"
+dependencies = [
+ "async-trait",
+ "deadpool-runtime",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
 name = "deranged"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -743,6 +777,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "fancy-regex"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -752,6 +796,12 @@ dependencies = [
  "regex-automata 0.4.9",
  "regex-syntax 0.8.5",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "float-cmp"
@@ -808,6 +858,21 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -969,6 +1034,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
+name = "h2"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 0.2.12",
+ "indexmap 2.8.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17da50a276f1e01e0ba6c029e47b7100754904ee8a278f886546e98575380785"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http 1.3.1",
+ "indexmap 2.8.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1020,10 +1123,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
 
 [[package]]
 name = "http"
@@ -1038,12 +1158,23 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http",
+ "http 1.3.1",
 ]
 
 [[package]]
@@ -1054,8 +1185,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.3.1",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -1064,6 +1195,12 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "human-panic"
@@ -1083,6 +1220,30 @@ dependencies = [
 
 [[package]]
 name = "hyper"
+version = "0.14.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.27",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
@@ -1090,14 +1251,29 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http",
- "http-body",
+ "h2 0.4.11",
+ "http 1.3.1",
+ "http-body 1.0.1",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper 0.14.32",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
 ]
 
 [[package]]
@@ -1109,9 +1285,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "hyper 1.6.0",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -1366,7 +1542,7 @@ dependencies = [
  "referencing",
  "regex",
  "regex-syntax 0.8.5",
- "reqwest",
+ "reqwest 0.12.15",
  "serde",
  "serde_json",
  "uuid-simd",
@@ -1410,6 +1586,12 @@ dependencies = [
  "bitflags 2.9.0",
  "libc",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "litemap"
@@ -1545,6 +1727,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1646,6 +1845,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi 0.5.2",
+ "libc",
+]
+
+[[package]]
 name = "object"
 version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1713,10 +1922,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl"
+version = "0.10.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
+dependencies = [
+ "bitflags 2.9.0",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "option-ext"
@@ -1880,6 +2127,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "pkg_v"
@@ -2162,6 +2415,46 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
+version = "0.11.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
+dependencies = [
+ "base64 0.21.7",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.27",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
+ "hyper-tls",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pemfile 1.0.4",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper 0.1.2",
+ "system-configuration",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.12.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d19c46a6fdd48bc4dab94b6103fccc55d34c67cc0ad04653aad4ea2a07cd7bbb"
@@ -2171,10 +2464,10 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "http",
- "http-body",
+ "http 1.3.1",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.6.0",
  "hyper-util",
  "ipnet",
  "js-sys",
@@ -2186,7 +2479,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tokio",
  "tower",
  "tower-service",
@@ -2320,6 +2613,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
+dependencies = [
+ "bitflags 2.9.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2714,6 +3020,12 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
@@ -2730,6 +3042,40 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.100",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.1",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2883,6 +3229,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-rustls"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2900,6 +3256,19 @@ checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
 dependencies = [
  "rustls 0.22.4",
  "rustls-pki-types",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
  "tokio",
 ]
 
@@ -2946,7 +3315,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "pin-project-lite",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tokio",
  "tower-layer",
  "tower-service",
@@ -3182,6 +3551,25 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vault"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "reqwest 0.11.27",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "wiremock",
+]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version-compare"
@@ -3609,6 +3997,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e97b544156e9bebe1a0ffbc03484fc1ffe3100cbce3ffb17eac35f7cdd7ab36"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winreg"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "wiremock"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b8b99d4cdbf36b239a9532e31fe4fb8acc38d1897c1761e161550a7dc78e6a"
+dependencies = [
+ "assert-json-diff",
+ "async-trait",
+ "base64 0.22.1",
+ "deadpool",
+ "futures",
+ "http 1.3.1",
+ "http-body-util",
+ "hyper 1.6.0",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ members = [
     "examples/concurrency/pkg_a/blocks/blk-b",
     "examples/flows/pkg/pkg_v-0.1.0/blocks/blk-b",
     "layer",
+    "vault",
 ]
 
 [features]

--- a/vault/Cargo.toml
+++ b/vault/Cargo.toml
@@ -8,8 +8,8 @@ reqwest = { version = "0.11", features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1.0", features = ["full"] }
-anyhow = "1.0"
 tracing = "0.1.41"
+utils = { path = "../utils" }
 
 [dev-dependencies]
 wiremock = "0.6.4"

--- a/vault/Cargo.toml
+++ b/vault/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "vault"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+reqwest = { version = "0.11", features = ["json"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+tokio = { version = "1.0", features = ["full"] }
+anyhow = "1.0"
+tracing = "0.1.41"
+
+[dev-dependencies]
+wiremock = "0.6.4"

--- a/vault/src/lib.rs
+++ b/vault/src/lib.rs
@@ -1,0 +1,353 @@
+use anyhow::{Result, anyhow};
+use reqwest::Client;
+use serde::Deserialize;
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+use tracing::{debug, info, warn};
+
+const DEFAULT_MAX_RETRIES: u32 = 2;
+const DEFAULT_TIMEOUT_SECS: u64 = 5;
+
+/// Lightweight structure specifically for extracting the value field
+#[derive(Debug, Deserialize)]
+struct VaultValueOnly {
+    value: HashMap<String, String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct VaultClient {
+    pub domain: String,
+    pub api_key: String,
+    pub max_retries: u32,
+    pub timeout_secs: u64,
+}
+
+impl VaultClient {
+    pub fn new(domain: String, api_key: String) -> Self {
+        Self {
+            domain,
+            api_key,
+            max_retries: DEFAULT_MAX_RETRIES,
+            timeout_secs: DEFAULT_TIMEOUT_SECS,
+        }
+    }
+
+    pub fn with_max_retries(mut self, max_retries: u32) -> Self {
+        self.max_retries = max_retries;
+        self
+    }
+
+    pub fn with_timeout_secs(mut self, timeout_secs: u64) -> Self {
+        self.timeout_secs = timeout_secs;
+        self
+    }
+
+    /// Fetch vaultlet value by ID
+    ///
+    /// # Arguments
+    ///
+    /// * `id` - vaultlet ID
+    ///
+    /// # Returns
+    ///
+    /// Returns the value data from vaultlet as HashMap<String, String>
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use vault::VaultClient;
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> anyhow::Result<()> {
+    ///     let client = VaultClient::new(
+    ///         "http://127.0.0.1:7893".to_string(),
+    ///         "your-api-key".to_string()
+    ///     ).with_max_retries(5)
+    ///      .with_timeout_secs(10);
+    ///     
+    ///     let value = client.fetch("vault-id".to_string()).await?;
+    ///     println!("{:?}", value);
+    ///     Ok(())
+    /// }
+    /// ```
+    pub async fn fetch(&self, id: String) -> Result<HashMap<String, String>> {
+        let start_time = Instant::now();
+        let client: Client = Client::new();
+        let url = format!("{}/v1/vaultlet/{}", self.domain, id);
+        let auth_header = format!("Bearer api-{}", self.api_key);
+
+        for attempt in 0..=self.max_retries {
+            let response = client
+                .get(&url)
+                .header("Authorization", &auth_header)
+                .timeout(Duration::from_secs(self.timeout_secs))
+                .send()
+                .await;
+
+            match response {
+                Ok(resp) => {
+                    let status = resp.status();
+
+                    if status.is_success() {
+                        log_request_duration(&id, start_time, "completed");
+                        return parse_vaultlet_response(resp).await;
+                    } else if should_retry(status, attempt, self.max_retries) {
+                        warn!(
+                            "Request failed with status {}, retrying... (attempt {}/{})",
+                            status,
+                            attempt + 1,
+                            self.max_retries + 1
+                        );
+                        continue;
+                    } else {
+                        log_request_duration(
+                            &id,
+                            start_time,
+                            &format!("failed with status: {}", status),
+                        );
+                        return Err(create_status_error(status, self.max_retries));
+                    }
+                }
+                Err(e) => {
+                    if attempt < self.max_retries {
+                        warn!(
+                            "Request failed with error: {}, retrying... (attempt {}/{})",
+                            e,
+                            attempt + 1,
+                            self.max_retries + 1
+                        );
+                        continue;
+                    } else {
+                        log_request_duration(&id, start_time, &format!("failed with error: {}", e));
+                        return Err(anyhow!(
+                            "Request failed after {} retries: {}",
+                            self.max_retries,
+                            e
+                        ));
+                    }
+                }
+            }
+        }
+
+        unreachable!("Loop should have returned or continued")
+    }
+}
+
+fn log_request_duration(id: &str, start_time: Instant, status: &str) {
+    let elapsed = start_time.elapsed();
+    let duration_secs = elapsed.as_secs_f64();
+
+    if elapsed >= Duration::from_secs(2) {
+        info!(
+            "Vault request for ID '{}' {} in {:.2}s",
+            id, status, duration_secs
+        );
+    } else {
+        debug!(
+            "Vault request for ID '{}' {} in {:.2}s",
+            id, status, duration_secs
+        );
+    }
+}
+
+async fn parse_vaultlet_response(resp: reqwest::Response) -> Result<HashMap<String, String>> {
+    let vault_data: VaultValueOnly = resp
+        .json()
+        .await
+        .map_err(|e| anyhow!("Failed to parse JSON response: {}", e))?;
+
+    Ok(vault_data.value)
+}
+
+fn should_retry(status: reqwest::StatusCode, attempt: u32, max_retries: u32) -> bool {
+    status.as_u16() >= 500 && attempt < max_retries
+}
+
+fn create_status_error(status: reqwest::StatusCode, max_retries: u32) -> anyhow::Error {
+    if status.as_u16() >= 500 {
+        anyhow!("Server error after {} retries: {}", max_retries, status)
+    } else {
+        anyhow!("Client error: {}", status)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use wiremock::{
+        Mock, MockServer, ResponseTemplate,
+        matchers::{header, method, path},
+    };
+
+    #[tokio::test]
+    async fn test_vault_client_creation() {
+        let client = VaultClient::new("http://127.0.0.1:7893".to_string(), "test-key".to_string());
+
+        assert_eq!(client.domain, "http://127.0.0.1:7893");
+        assert_eq!(client.api_key, "test-key");
+        assert_eq!(client.max_retries, DEFAULT_MAX_RETRIES);
+        assert_eq!(client.timeout_secs, DEFAULT_TIMEOUT_SECS);
+
+        let client_custom =
+            VaultClient::new("http://example.com".to_string(), "custom-key".to_string())
+                .with_max_retries(5)
+                .with_timeout_secs(10);
+
+        assert_eq!(client_custom.max_retries, 5);
+        assert_eq!(client_custom.timeout_secs, 10);
+    }
+
+    #[tokio::test]
+    async fn test_fetch_success() {
+        let mock_server = MockServer::start().await;
+
+        let mut expected_value = HashMap::new();
+        expected_value.insert("key1".to_string(), "value1".to_string());
+        expected_value.insert("key2".to_string(), "value2".to_string());
+
+        let response_body = serde_json::json!({
+            "value": expected_value
+        });
+
+        Mock::given(method("GET"))
+            .and(path("/v1/vaultlet/test-id"))
+            .and(header("Authorization", "Bearer api-test-key"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&response_body))
+            .mount(&mock_server)
+            .await;
+
+        let client = VaultClient::new(mock_server.uri(), "test-key".to_string());
+
+        let result = client.fetch("test-id".to_string()).await;
+        assert!(result.is_ok());
+
+        assert_eq!(result.unwrap(), expected_value);
+    }
+
+    #[tokio::test]
+    async fn test_fetch_client_error() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/v1/vaultlet/non-existent"))
+            .and(header("Authorization", "Bearer api-test-key"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&mock_server)
+            .await;
+
+        let client = VaultClient::new(mock_server.uri(), "test-key".to_string());
+
+        // Test client error (should not retry)
+        let result = client.fetch("non-existent".to_string()).await;
+        assert!(result.is_err());
+
+        let error_msg = result.unwrap_err().to_string();
+        assert!(error_msg.contains("Client error: 404"));
+    }
+
+    #[tokio::test]
+    async fn test_fetch_server_error_with_retry() {
+        let mock_server = MockServer::start().await;
+
+        let max_retries = DEFAULT_MAX_RETRIES;
+        let total_attempts = max_retries + 1; // initial attempt + retries
+
+        Mock::given(method("GET"))
+            .and(path("/v1/vaultlet/server-error"))
+            .and(header("Authorization", "Bearer api-test-key"))
+            .respond_with(ResponseTemplate::new(500))
+            .expect(total_attempts as u64) // Should be called total_attempts times
+            .mount(&mock_server)
+            .await;
+
+        let client = VaultClient::new(mock_server.uri(), "test-key".to_string());
+
+        // Test server error (should retry and eventually fail)
+        let result = client.fetch("server-error".to_string()).await;
+        assert!(result.is_err());
+
+        let error_msg = result.unwrap_err().to_string();
+        assert!(error_msg.contains(&format!("Server error after {} retries: 500", max_retries)));
+    }
+
+    #[tokio::test]
+    async fn test_fetch_server_error_then_success() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/v1/vaultlet/retry-success"))
+            .and(header("Authorization", "Bearer api-test-key"))
+            .respond_with(ResponseTemplate::new(500))
+            .up_to_n_times(1)
+            .mount(&mock_server)
+            .await;
+
+        let mut expected_value = HashMap::new();
+        expected_value.insert("retried".to_string(), "success".to_string());
+
+        let response_body = serde_json::json!({
+            "value": expected_value
+        });
+
+        Mock::given(method("GET"))
+            .and(path("/v1/vaultlet/retry-success"))
+            .and(header("Authorization", "Bearer api-test-key"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&response_body))
+            .mount(&mock_server)
+            .await;
+
+        let client = VaultClient::new(mock_server.uri(), "test-key".to_string());
+
+        let result = client.fetch("retry-success".to_string()).await;
+        assert!(result.is_ok());
+
+        let value = result.unwrap();
+        assert_eq!(value.get("retried"), Some(&"success".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_fetch_invalid_json() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/v1/vaultlet/invalid-json"))
+            .and(header("Authorization", "Bearer api-test-key"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("invalid json"))
+            .mount(&mock_server)
+            .await;
+
+        let client = VaultClient::new(mock_server.uri(), "test-key".to_string());
+
+        let result = client.fetch("invalid-json".to_string()).await;
+        assert!(result.is_err());
+
+        let error_msg: String = result.unwrap_err().to_string();
+        assert!(error_msg.contains("Failed to parse JSON response"));
+    }
+
+    #[tokio::test]
+    async fn test_fetch_timeout() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/v1/vaultlet/timeout-test"))
+            .and(header("Authorization", "Bearer api-test-key"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(&serde_json::json!({"value": {"test": "value"}}))
+                    .set_delay(std::time::Duration::from_secs(2)),
+            )
+            .mount(&mock_server)
+            .await;
+
+        let client =
+            VaultClient::new(mock_server.uri(), "test-key".to_string()).with_timeout_secs(1);
+
+        let result = client.fetch("timeout-test".to_string()).await;
+        assert!(result.is_err());
+
+        let error_msg = result.unwrap_err().to_string();
+        assert!(error_msg.contains("timeout"));
+    }
+}


### PR DESCRIPTION
Vault is our new key service for storing user Secrets (in KV format) and OAuth2 Credentials.Since OAuth2 Credentials have “dynamic” behavior, such as AccessTokens which have a lifespan, for example, Google’s AccessToken is only valid for 1 hour.

To address this issue, we need to enable oocana to request the vault service while ensuring that oocana can run independently (without needing to start other services at the same time).


close: #304