### PR TITLE
refactor: reduce block option field

### DIFF
--- a/manifest_meta/src/block.rs
+++ b/manifest_meta/src/block.rs
@@ -13,11 +13,11 @@ pub enum Block {
 }
 
 impl Block {
-    pub fn path_str(&self) -> Option<&String> {
+    pub fn path_str(&self) -> Option<String> {
         match self {
-            Block::Task(task) => task.path_str.as_ref(),
-            Block::Flow(flow) => Some(&flow.path_str),
-            Block::Slot(slot) => slot.path_str.as_ref(),
+            Block::Task(task) => task.path_str(),
+            Block::Flow(flow) => Some(flow.path_str.clone()),
+            Block::Slot(_) => None,
             Block::Service(_) => None,
         }
     }

--- a/manifest_meta/src/block_resolver.rs
+++ b/manifest_meta/src/block_resolver.rs
@@ -78,7 +78,7 @@ impl BlockResolver {
     ) -> Result<Arc<SlotBlock>> {
         match slot_node_block {
             manifest::SlotNodeBlock::Inline(block) => {
-                let slot_block = SlotBlock::from_manifest(block, None, None);
+                let slot_block = SlotBlock::from_manifest(block);
                 Ok(Arc::new(slot_block))
             }
         }

--- a/manifest_meta/src/node/definition.rs
+++ b/manifest_meta/src/node/definition.rs
@@ -202,7 +202,7 @@ impl Node {
         match self {
             Self::Task(task) => task.task.package_path.clone(),
             Self::Flow(flow) => flow.flow.package_path.clone(),
-            Self::Slot(slot) => slot.slot.package_path.clone(),
+            Self::Slot(_) => None,
             Self::Service(service) => service.block.package_path.clone(),
         }
     }

--- a/manifest_meta/src/slot.rs
+++ b/manifest_meta/src/slot.rs
@@ -1,22 +1,13 @@
-use std::path::PathBuf;
-
 use manifest_reader::manifest::{self, InputHandles, OutputHandles};
 
 #[derive(Debug, Clone)]
 pub struct SlotBlock {
     pub inputs_def: Option<InputHandles>,
     pub outputs_def: Option<OutputHandles>,
-    pub path: Option<PathBuf>,
-    pub path_str: Option<String>,
-    pub package_path: Option<PathBuf>,
 }
 
 impl SlotBlock {
-    pub fn from_manifest(
-        manifest: manifest::SlotBlock,
-        path: Option<PathBuf>,
-        package_path: Option<PathBuf>,
-    ) -> Self {
+    pub fn from_manifest(manifest: manifest::SlotBlock) -> Self {
         let manifest::SlotBlock {
             inputs_def,
             outputs_def,
@@ -25,9 +16,6 @@ impl SlotBlock {
         Self {
             inputs_def,
             outputs_def,
-            path_str: path.as_ref().map(|path| path.to_string_lossy().to_string()),
-            path,
-            package_path,
         }
     }
 }

--- a/manifest_meta/src/task.rs
+++ b/manifest_meta/src/task.rs
@@ -10,9 +10,8 @@ pub struct TaskBlock {
     pub executor: TaskBlockExecutor,
     pub inputs_def: Option<InputHandles>,
     pub outputs_def: Option<OutputHandles>,
-    /// block.oo.[yml|yaml] 的路径；如果是 inline block，这个字段为空。
+    // None means this task block is inline script block
     pub path: Option<PathBuf>,
-    pub path_str: Option<String>,
     pub additional_inputs: bool,
     pub additional_outputs: bool,
     // TODO: package_path is not reliable, it should be removed. use block type instead.
@@ -24,9 +23,8 @@ impl TaskBlock {
         self.executor.entry()
     }
 
-    // script 小脚本，首先是 TaskNodeBlock File 类型。但是这里没办法自己判断。
     fn is_script_block(&self) -> bool {
-        self.executor.is_script()
+        self.path.is_none()
     }
 
     pub fn block_dir(&self) -> Option<PathBuf> {
@@ -39,6 +37,12 @@ impl TaskBlock {
         } else {
             None
         }
+    }
+
+    pub fn path_str(&self) -> Option<String> {
+        self.path
+            .as_ref()
+            .map(|path| path.to_string_lossy().to_string())
     }
 }
 
@@ -62,7 +66,6 @@ impl TaskBlock {
             inputs_def,
             description,
             outputs_def,
-            path_str: path.as_ref().map(|path| path.to_string_lossy().to_string()),
             path,
             package_path: package,
             additional_inputs,

--- a/runtime/src/block_job/task_job.rs
+++ b/runtime/src/block_job/task_job.rs
@@ -75,7 +75,7 @@ pub fn execute_task_job(params: TaskJobParameters) -> Option<BlockJobHandle> {
     } = params;
     let reporter = Arc::new(shared.reporter.block(
         job_id.to_owned(),
-        task_block.path_str.clone(),
+        task_block.path_str(),
         stacks.clone(),
     ));
 
@@ -96,7 +96,7 @@ pub fn execute_task_job(params: TaskJobParameters) -> Option<BlockJobHandle> {
 
     let worker_listener_handle = listen_to_worker(ListenerArgs {
         job_id: job_id.to_owned(),
-        block_path: task_block.path_str.clone(),
+        block_path: task_block.path_str(),
         stacks: stacks.clone(),
         scheduler_tx: shared.scheduler_tx.clone(),
         inputs: inputs.clone(),
@@ -185,7 +185,8 @@ pub fn execute_task_job(params: TaskJobParameters) -> Option<BlockJobHandle> {
                         if status_code != 0 {
                             let msg = format!(
                                 "Task block '{:?}' exited with code {}",
-                                task_block.path_str, status_code
+                                task_block.path_str(),
+                                status_code
                             );
                             shared_clone.scheduler_tx.send_block_event(
                                 scheduler::ReceiveMessage::BlockFinished {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -88,10 +88,7 @@ pub async fn run(args: RunArgs<'_>) -> Result<()> {
         }
     };
 
-    let block_path = block
-        .path_str()
-        .map(|p| p.to_owned())
-        .unwrap_or_else(|| block_name.to_string());
+    let block_path = block.path_str().unwrap_or_else(|| block_name.to_string());
 
     shared.reporter.session_started(&block_path, partial, cache);
 
@@ -537,10 +534,7 @@ pub fn find_upstream(
         }
     };
 
-    let block_path = block
-        .path_str()
-        .map(|p| p.to_owned())
-        .unwrap_or_else(|| block_name.to_string());
+    let block_path = block.path_str().unwrap_or_else(|| block_name.to_string());
 
     match block {
         Block::Flow(flow) => {

--- a/runtime/src/run/mod.rs
+++ b/runtime/src/run/mod.rs
@@ -120,21 +120,14 @@ pub fn run_job(params: JobParams) -> Option<BlockJobHandle> {
             scope: common.scope,
             inputs_def_patch,
         }),
-        JobParams::Slot {
-            slot_block,
-            common: shared,
-            ..
-        } => {
+        JobParams::Slot { common: shared, .. } => {
             shared
                 .shared
                 .reporter
                 .send(mainframe::reporter::ReporterMessage::BlockFinished {
                     session_id: &shared.shared.session_id,
                     job_id: &shared.job_id,
-                    block_path: &slot_block
-                        .path
-                        .as_ref()
-                        .map(|path| path.to_string_lossy().to_string()),
+                    block_path: &None,
                     stacks: shared.stacks.vec(),
                     error: Some("Cannot run Slot Block directly".to_string()),
                     result: None,

--- a/runtime/src/run/mod.rs
+++ b/runtime/src/run/mod.rs
@@ -52,6 +52,7 @@ pub enum JobParams {
         common: CommonJobParameters,
     },
     Slot {
+        #[allow(dead_code)]
         slot_block: Arc<SlotBlock>,
         common: CommonJobParameters,
     },


### PR DESCRIPTION
1. task block: use function `path_str` instead of path_str field, make path_str link to path
2. remove slot block's path and package since it is a empty block