### PR TITLE
feat(runtime): add connector executor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2516,6 +2516,7 @@ dependencies = [
 name = "runtime"
 version = "0.30.47"
 dependencies = [
+ "async-trait",
  "dirs",
  "flume 0.11.1",
  "job",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2527,6 +2527,7 @@ dependencies = [
  "path-clean",
  "rand 0.8.5",
  "remote_job_client",
+ "reqwest",
  "serde",
  "serde_json",
  "tokio",
@@ -2534,6 +2535,7 @@ dependencies = [
  "utils",
  "uuid",
  "vault",
+ "wiremock",
 ]
 
 [[package]]

--- a/manifest_reader/src/manifest/block/task.rs
+++ b/manifest_reader/src/manifest/block/task.rs
@@ -65,6 +65,7 @@ pub struct TaskBlock {
 pub enum TaskBlockExecutor {
     NodeJS(NodeJSExecutor),
     Python(PythonExecutor),
+    Connector(ConnectorExecutor),
     Shell(ShellExecutor),
     Rust(RustExecutor),
 }
@@ -94,6 +95,7 @@ impl TaskBlockExecutor {
         match self {
             TaskBlockExecutor::NodeJS(_) => "nodejs",
             TaskBlockExecutor::Python(_) => "python",
+            TaskBlockExecutor::Connector(_) => "connector",
             TaskBlockExecutor::Shell(_) => "shell",
             TaskBlockExecutor::Rust(_) => "rust",
         }
@@ -130,6 +132,7 @@ impl TaskBlockExecutor {
             TaskBlockExecutor::Python(PythonExecutor { options }) => {
                 options.as_ref().is_some_and(|o| o.spawn)
             }
+            TaskBlockExecutor::Connector(_) => false,
             TaskBlockExecutor::Shell(_) => false,
             TaskBlockExecutor::Rust(_) => false,
         }
@@ -146,6 +149,16 @@ pub struct NodeJSExecutor {
 pub struct PythonExecutor {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub options: Option<ExecutorOptions>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ConnectorExecutor {
+    pub options: ConnectorExecutorOptions,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct ConnectorExecutorOptions {
+    pub action: String,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -352,6 +365,18 @@ mod test {
         match deserialized {
             TaskBlockExecutor::Shell(ShellExecutor { .. }) => {}
             _ => panic!("Expected ShellExecutor"),
+        }
+    }
+
+    #[test]
+    fn deserialize_connector_executor() {
+        let serialized = r#"{"name":"connector","options":{"action":"run-action"}}"#;
+        let deserialized: TaskBlockExecutor = serde_json::from_str(serialized).unwrap();
+        match deserialized {
+            TaskBlockExecutor::Connector(e) => {
+                assert_eq!(e.options.action, "run-action");
+            }
+            _ => panic!("Expected ConnectorExecutor"),
         }
     }
 

--- a/one_shot/src/one_shot.rs
+++ b/one_shot/src/one_shot.rs
@@ -304,6 +304,7 @@ async fn run_block_async(block_args: BlockArgs<'_>) -> Result<()> {
     let shared = Arc::new(runtime::shared::Shared {
         session_id: session_id.clone(),
         address: addr.to_string(),
+        connector_auth_token: runtime::remote_task_config::resolve_auth_token(&env_file_vars),
         scheduler_tx: scheduler_tx.clone(),
         delay_abort_tx,
         reporter: reporter_tx.clone(),

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -24,3 +24,7 @@ flume = { version = "0.11.0", default-features = false, features = ["async"] }
 dirs = "5.0.1"
 uuid = { version = "1.3.0", features = ["v4", "fast-rng", "macro-diagnostics"] }
 jsonschema = "0.30.0"
+reqwest = { version = "0.12", features = ["rustls-tls", "json"], default-features = false }
+
+[dev-dependencies]
+wiremock = "0.6.4"

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -27,4 +27,5 @@ jsonschema = "0.30.0"
 reqwest = { version = "0.12", features = ["rustls-tls", "json"], default-features = false }
 
 [dev-dependencies]
+async-trait = "0.1.74"
 wiremock = "0.6.4"

--- a/runtime/src/block_job/task_job.rs
+++ b/runtime/src/block_job/task_job.rs
@@ -5,12 +5,13 @@ use manifest_meta::{
     TaskBlockExecutor,
 };
 use manifest_reader::manifest::SpawnOptions;
-use reqwest::Client;
+use reqwest::{Client, Url};
 
 use std::collections::HashMap;
 use std::path::Path;
 use std::process;
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, OnceLock, RwLock};
+use std::time::Duration;
 use tokio::io::{AsyncBufReadExt, BufReader};
 
 use crate::block_status::BlockStatusTx;
@@ -24,6 +25,13 @@ use super::job_handle::BlockJobHandle;
 use super::listener::{ListenerParameters, listen_to_worker};
 
 const CONNECTOR_BASE_URL_ENV_KEY: &str = "CONNECTOR_BASE_URL";
+const DEFAULT_CONNECTOR_REQUEST_TIMEOUT_SECS: u64 = 30;
+const CONNECTOR_ERROR_BODY_LIMIT: usize = 512;
+
+fn connector_http_client() -> &'static Client {
+    static CLIENT: OnceLock<Client> = OnceLock::new();
+    CLIENT.get_or_init(Client::new)
+}
 
 pub struct TaskJobHandle {
     pub job_id: JobId,
@@ -239,9 +247,12 @@ pub fn execute_task_job(params: TaskJobParameters) -> Option<BlockJobHandle> {
             let session_id = shared.session_id.clone();
             let job_id_clone = job_id.clone();
             let connector_inputs = inputs.clone();
+            let request_timeout =
+                Duration::from_secs(timeout.unwrap_or(DEFAULT_CONNECTOR_REQUEST_TIMEOUT_SECS));
 
             let connector_handle = tokio::spawn(async move {
-                let result = run_connector_action(&action_id, connector_inputs).await;
+                let result =
+                    run_connector_action(&action_id, connector_inputs, request_timeout).await;
 
                 match result {
                     Ok(outputs) => {
@@ -412,6 +423,7 @@ fn get_string_value_from_inputs(inputs: &Option<BlockInputs>, key: &str) -> Opti
 async fn run_connector_action(
     action_id: &str,
     inputs: Option<BlockInputs>,
+    request_timeout: Duration,
 ) -> Result<HashMap<HandleName, serde_json::Value>> {
     let base_url = std::env::var(CONNECTOR_BASE_URL_ENV_KEY).map_err(|_| {
         utils::error::Error::new(&format!(
@@ -419,27 +431,25 @@ async fn run_connector_action(
         ))
     })?;
 
-    run_connector_action_with_base_url(&base_url, action_id, inputs).await
+    run_connector_action_with_base_url(&base_url, action_id, inputs, request_timeout).await
 }
 
 async fn run_connector_action_with_base_url(
     base_url: &str,
     action_id: &str,
     inputs: Option<BlockInputs>,
+    request_timeout: Duration,
 ) -> Result<HashMap<HandleName, serde_json::Value>> {
-    let url = format!(
-        "{}/v1/actions/{}",
-        base_url.trim_end_matches('/'),
-        action_id
-    );
+    let url = build_connector_action_url(base_url, action_id)?;
 
     let request_body = serde_json::json!({
         "input": serialize_connector_inputs(inputs),
     });
 
-    let response = Client::new()
-        .post(&url)
+    let response = connector_http_client()
+        .post(url.clone())
         .json(&request_body)
+        .timeout(request_timeout)
         .send()
         .await
         .map_err(|e| {
@@ -455,7 +465,8 @@ async fn run_connector_action_with_base_url(
         let message = if body.is_empty() {
             format!("Connector action '{action_id}' failed with status {status}")
         } else {
-            format!("Connector action '{action_id}' failed with status {status}: {body}")
+            let truncated = truncate_connector_error_body(&body);
+            format!("Connector action '{action_id}' failed with status {status}: {truncated}")
         };
 
         return Err(utils::error::Error::new(&message));
@@ -471,12 +482,43 @@ async fn run_connector_action_with_base_url(
     parse_connector_outputs(action_id, response_json)
 }
 
+fn build_connector_action_url(base_url: &str, action_id: &str) -> Result<Url> {
+    let mut url = Url::parse(base_url).map_err(|e| {
+        utils::error::Error::with_source(
+            &format!("Invalid {CONNECTOR_BASE_URL_ENV_KEY}: '{base_url}'"),
+            Box::new(e),
+        )
+    })?;
+
+    {
+        let mut segments = url.path_segments_mut().map_err(|_| {
+            utils::error::Error::new(&format!(
+                "Invalid {CONNECTOR_BASE_URL_ENV_KEY}: '{base_url}'"
+            ))
+        })?;
+        segments.pop_if_empty();
+        segments.extend(["v1", "actions", action_id]);
+    }
+
+    Ok(url)
+}
+
 fn serialize_connector_inputs(inputs: Option<BlockInputs>) -> HashMap<String, serde_json::Value> {
     inputs
         .unwrap_or_default()
         .into_iter()
         .map(|(handle, value)| (handle.to_string(), value.value.clone()))
         .collect()
+}
+
+fn truncate_connector_error_body(body: &str) -> String {
+    let mut chars = body.chars();
+    let truncated: String = chars.by_ref().take(CONNECTOR_ERROR_BODY_LIMIT).collect();
+    if chars.next().is_some() {
+        format!("{truncated}...<truncated>")
+    } else {
+        truncated
+    }
 }
 
 fn parse_connector_outputs(
@@ -705,10 +747,14 @@ mod tests {
             .mount(&mock_server)
             .await;
 
-        let outputs =
-            run_connector_action_with_base_url(&mock_server.uri(), "run-action", Some(inputs))
-                .await
-                .unwrap();
+        let outputs = run_connector_action_with_base_url(
+            &mock_server.uri(),
+            "run-action",
+            Some(inputs),
+            Duration::from_secs(30),
+        )
+        .await
+        .unwrap();
 
         assert_eq!(
             outputs.get(&HandleName::from("result")),
@@ -729,5 +775,59 @@ mod tests {
             error.to_string(),
             "Connector action 'run-action' response data field must be an object"
         );
+    }
+
+    #[tokio::test]
+    async fn connector_executor_requires_data_field() {
+        let error = parse_connector_outputs("run-action", serde_json::json!({})).unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            "Connector action 'run-action' response is missing data field"
+        );
+    }
+
+    #[tokio::test]
+    async fn connector_executor_reports_non_success_status() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/v1/actions/run-action"))
+            .respond_with(ResponseTemplate::new(500).set_body_string("connector failed"))
+            .mount(&mock_server)
+            .await;
+
+        let error = run_connector_action_with_base_url(
+            &mock_server.uri(),
+            "run-action",
+            None,
+            Duration::from_secs(30),
+        )
+        .await
+        .unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            "Connector action 'run-action' failed with status 500 Internal Server Error: connector failed"
+        );
+    }
+
+    #[test]
+    fn connector_executor_encodes_action_id_as_single_path_segment() {
+        let url = build_connector_action_url("https://connector.example/base", "a/b ?c#d").unwrap();
+
+        assert_eq!(
+            url.as_str(),
+            "https://connector.example/base/v1/actions/a%2Fb%20%3Fc%23d"
+        );
+    }
+
+    #[test]
+    fn connector_executor_truncates_large_error_bodies() {
+        let body = "x".repeat(CONNECTOR_ERROR_BODY_LIMIT + 10);
+        let truncated = truncate_connector_error_body(&body);
+
+        assert!(truncated.ends_with("...<truncated>"));
+        assert!(truncated.len() > CONNECTOR_ERROR_BODY_LIMIT);
     }
 }

--- a/runtime/src/block_job/task_job.rs
+++ b/runtime/src/block_job/task_job.rs
@@ -480,6 +480,7 @@ async fn run_connector_action_with_auth_token(
     .await
 }
 
+#[cfg(test)]
 async fn run_connector_action_with_base_url(
     base_url: &str,
     action_id: &str,

--- a/runtime/src/block_job/task_job.rs
+++ b/runtime/src/block_job/task_job.rs
@@ -538,12 +538,7 @@ async fn run_connector_action_with_base_url_and_auth(
     let status = response.status();
     if !status.is_success() {
         let body = response.text().await.unwrap_or_default();
-        let message = if body.is_empty() {
-            format!("Connector action '{action_id}' failed with status {status}")
-        } else {
-            let truncated = truncate_connector_error_body(&body);
-            format!("Connector action '{action_id}' failed with status {status}: {truncated}")
-        };
+        let message = format_connector_http_error(action_id, status, &body);
 
         return Err(utils::error::Error::new(&message));
     }
@@ -597,6 +592,73 @@ fn truncate_connector_error_body(body: &str) -> String {
     }
 }
 
+fn format_connector_http_error(
+    action_id: &str,
+    status: reqwest::StatusCode,
+    body: &str,
+) -> String {
+    if body.is_empty() {
+        return format!("Connector action '{action_id}' failed with status {status}");
+    }
+
+    if let Ok(response_json) = serde_json::from_str::<serde_json::Value>(body) {
+        if let Some(details) = format_connector_error_details(&response_json) {
+            return format!("Connector action '{action_id}' failed with status {status}: {details}");
+        }
+    }
+
+    let truncated = truncate_connector_error_body(body);
+    format!("Connector action '{action_id}' failed with status {status}: {truncated}")
+}
+
+fn format_connector_error_details(response_json: &serde_json::Value) -> Option<String> {
+    let message = response_json
+        .get("message")
+        .and_then(|value| value.as_str())
+        .filter(|message| !message.trim().is_empty())
+        .or_else(|| {
+            response_json
+                .get("errorMessage")
+                .and_then(|value| value.as_str())
+                .filter(|message| !message.trim().is_empty())
+        })?;
+
+    let mut metadata = Vec::new();
+
+    if let Some(error_code) = response_json
+        .get("errorCode")
+        .and_then(|value| value.as_str())
+        .filter(|error_code| !error_code.trim().is_empty())
+    {
+        metadata.push(format!("errorCode={error_code}"));
+    }
+
+    if let Some(action_id) = response_json
+        .get("meta")
+        .and_then(|value| value.get("actionId"))
+        .and_then(|value| value.as_str())
+        .filter(|action_id| !action_id.trim().is_empty())
+    {
+        metadata.push(format!("actionId={action_id}"));
+    }
+
+    let execution_id = response_json
+        .get("meta")
+        .and_then(|value| value.get("executionId"))
+        .or_else(|| response_json.get("executionId"))
+        .and_then(|value| value.as_str())
+        .filter(|execution_id| !execution_id.trim().is_empty());
+    if let Some(execution_id) = execution_id {
+        metadata.push(format!("executionId={execution_id}"));
+    }
+
+    if metadata.is_empty() {
+        Some(message.to_owned())
+    } else {
+        Some(format!("{message} ({})", metadata.join(", ")))
+    }
+}
+
 fn parse_connector_outputs(
     action_id: &str,
     response_json: serde_json::Value,
@@ -611,11 +673,8 @@ fn parse_connector_outputs(
         })?;
 
     if !success {
-        let message = response_json
-            .get("message")
-            .and_then(|value| value.as_str())
-            .filter(|message| !message.trim().is_empty())
-            .unwrap_or("unknown error");
+        let message =
+            format_connector_error_details(&response_json).unwrap_or_else(|| "unknown error".to_owned());
         return Err(utils::error::Error::new(&format!(
             "Connector action '{action_id}' failed: {message}"
         )));
@@ -963,6 +1022,103 @@ mod tests {
         assert_eq!(
             error.to_string(),
             "Connector action 'run-action' failed with status 500 Internal Server Error: connector failed"
+        );
+    }
+
+    #[tokio::test]
+    async fn connector_executor_reports_structured_4xx_status() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/v1/actions/run-action"))
+            .respond_with(ResponseTemplate::new(400).set_body_json(serde_json::json!({
+                "success": false,
+                "message": "input validation failed",
+                "data": null,
+                "errorCode": "invalid_input",
+                "meta": {
+                    "actionId": "run-action",
+                    "executionId": "exec-400"
+                }
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let error = run_connector_action_with_base_url(
+            &mock_server.uri(),
+            "run-action",
+            None,
+            Duration::from_secs(30),
+        )
+        .await
+        .unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            "Connector action 'run-action' failed with status 400 Bad Request: input validation failed (errorCode=invalid_input, actionId=run-action, executionId=exec-400)"
+        );
+    }
+
+    #[tokio::test]
+    async fn connector_executor_reports_structured_401_status() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/v1/actions/run-action"))
+            .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+                "errorCode": "invalid_input",
+                "errorMessage": "missing authorization header",
+                "executionId": "exec-401"
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let error = run_connector_action_with_base_url(
+            &mock_server.uri(),
+            "run-action",
+            None,
+            Duration::from_secs(30),
+        )
+        .await
+        .unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            "Connector action 'run-action' failed with status 401 Unauthorized: missing authorization header (errorCode=invalid_input, executionId=exec-401)"
+        );
+    }
+
+    #[tokio::test]
+    async fn connector_executor_reports_structured_5xx_status() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/v1/actions/run-action"))
+            .respond_with(ResponseTemplate::new(500).set_body_json(serde_json::json!({
+                "success": false,
+                "message": "provider unavailable",
+                "data": null,
+                "errorCode": "provider_error",
+                "meta": {
+                    "actionId": "run-action",
+                    "executionId": "exec-500"
+                }
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let error = run_connector_action_with_base_url(
+            &mock_server.uri(),
+            "run-action",
+            None,
+            Duration::from_secs(30),
+        )
+        .await
+        .unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            "Connector action 'run-action' failed with status 500 Internal Server Error: provider unavailable (errorCode=provider_error, actionId=run-action, executionId=exec-500)"
         );
     }
 

--- a/runtime/src/block_job/task_job.rs
+++ b/runtime/src/block_job/task_job.rs
@@ -247,6 +247,7 @@ pub fn execute_task_job(params: TaskJobParameters) -> Option<BlockJobHandle> {
             let session_id = shared.session_id.clone();
             let job_id_clone = job_id.clone();
             let connector_inputs = inputs.clone();
+            let connector_outputs_def = outputs_def.clone();
             let connector_auth_token = shared.connector_auth_token.clone();
             let request_timeout =
                 Duration::from_secs(timeout.unwrap_or(DEFAULT_CONNECTOR_REQUEST_TIMEOUT_SECS));
@@ -256,12 +257,19 @@ pub fn execute_task_job(params: TaskJobParameters) -> Option<BlockJobHandle> {
                     run_connector_action_with_auth_token(
                         &action_id,
                         connector_inputs,
+                        connector_outputs_def,
                         request_timeout,
                         Some(token),
                     )
                     .await
                 } else {
-                    run_connector_action(&action_id, connector_inputs, request_timeout).await
+                    run_connector_action(
+                        &action_id,
+                        connector_inputs,
+                        connector_outputs_def,
+                        request_timeout,
+                    )
+                    .await
                 };
 
                 match result {
@@ -433,6 +441,7 @@ fn get_string_value_from_inputs(inputs: &Option<BlockInputs>, key: &str) -> Opti
 async fn run_connector_action(
     action_id: &str,
     inputs: Option<BlockInputs>,
+    outputs_def: Option<OutputHandles>,
     request_timeout: Duration,
 ) -> Result<HashMap<HandleName, serde_json::Value>> {
     let auth_token = std::env::var("OOMOL_TOKEN")
@@ -443,6 +452,7 @@ async fn run_connector_action(
     run_connector_action_with_auth_token(
         action_id,
         inputs,
+        outputs_def,
         request_timeout,
         auth_token.as_deref(),
     )
@@ -452,6 +462,7 @@ async fn run_connector_action(
 async fn run_connector_action_with_auth_token(
     action_id: &str,
     inputs: Option<BlockInputs>,
+    outputs_def: Option<OutputHandles>,
     request_timeout: Duration,
     auth_token: Option<&str>,
 ) -> Result<HashMap<HandleName, serde_json::Value>> {
@@ -474,6 +485,7 @@ async fn run_connector_action_with_auth_token(
         &base_url,
         action_id,
         inputs,
+        outputs_def,
         request_timeout,
         auth_token.as_deref(),
     )
@@ -485,6 +497,7 @@ async fn run_connector_action_with_base_url(
     base_url: &str,
     action_id: &str,
     inputs: Option<BlockInputs>,
+    outputs_def: Option<OutputHandles>,
     request_timeout: Duration,
 ) -> Result<HashMap<HandleName, serde_json::Value>> {
     let auth_token = std::env::var("OOMOL_TOKEN")
@@ -496,6 +509,7 @@ async fn run_connector_action_with_base_url(
         base_url,
         action_id,
         inputs,
+        outputs_def,
         request_timeout,
         auth_token.as_deref(),
     )
@@ -506,6 +520,7 @@ async fn run_connector_action_with_base_url_and_auth(
     base_url: &str,
     action_id: &str,
     inputs: Option<BlockInputs>,
+    outputs_def: Option<OutputHandles>,
     request_timeout: Duration,
     auth_token: Option<&str>,
 ) -> Result<HashMap<HandleName, serde_json::Value>> {
@@ -550,7 +565,7 @@ async fn run_connector_action_with_base_url_and_auth(
         )
     })?;
 
-    parse_connector_outputs(action_id, response_json)
+    parse_connector_outputs(action_id, response_json, outputs_def.as_ref())
 }
 
 fn build_connector_action_url(base_url: &str, action_id: &str) -> Result<Url> {
@@ -662,6 +677,7 @@ fn format_connector_error_details(response_json: &serde_json::Value) -> Option<S
 fn parse_connector_outputs(
     action_id: &str,
     response_json: serde_json::Value,
+    outputs_def: Option<&OutputHandles>,
 ) -> Result<HashMap<HandleName, serde_json::Value>> {
     let success = response_json
         .get("success")
@@ -686,6 +702,10 @@ fn parse_connector_outputs(
         ))
     })?;
 
+    if connector_uses_single_output_handle(outputs_def) {
+        return Ok(HashMap::from([(HandleName::from("output"), data.clone())]));
+    }
+
     let outputs = data.as_object().ok_or_else(|| {
         utils::error::Error::new(&format!(
             "Connector action '{action_id}' response data field must be an object"
@@ -696,6 +716,12 @@ fn parse_connector_outputs(
         .iter()
         .map(|(handle, value)| (HandleName::from(handle.clone()), value.clone()))
         .collect())
+}
+
+fn connector_uses_single_output_handle(outputs_def: Option<&OutputHandles>) -> bool {
+    outputs_def.is_some_and(|outputs| {
+        outputs.len() == 1 && outputs.contains_key(&HandleName::from("output"))
+    })
 }
 
 fn spawn(
@@ -920,7 +946,8 @@ mod tests {
             std::env::set_var("OOMOL_TOKEN", "test-token");
         }
 
-        let outputs = run_connector_action("run-action", Some(inputs), Duration::from_secs(30)).await;
+        let outputs =
+            run_connector_action("run-action", Some(inputs), None, Duration::from_secs(30)).await;
 
         unsafe {
             if let Some(value) = previous_connector_base_url {
@@ -955,6 +982,7 @@ mod tests {
                 "success": true,
                 "data": 1
             }),
+            None,
         )
         .unwrap_err();
 
@@ -971,6 +999,7 @@ mod tests {
             serde_json::json!({
                 "success": true
             }),
+            None,
         )
         .unwrap_err();
 
@@ -991,6 +1020,7 @@ mod tests {
                     "ignored": true
                 }
             }),
+            None,
         )
         .unwrap_err();
 
@@ -1013,6 +1043,7 @@ mod tests {
         let error = run_connector_action_with_base_url(
             &mock_server.uri(),
             "run-action",
+            None,
             None,
             Duration::from_secs(30),
         )
@@ -1048,6 +1079,7 @@ mod tests {
             &mock_server.uri(),
             "run-action",
             None,
+            None,
             Duration::from_secs(30),
         )
         .await
@@ -1076,6 +1108,7 @@ mod tests {
         let error = run_connector_action_with_base_url(
             &mock_server.uri(),
             "run-action",
+            None,
             None,
             Duration::from_secs(30),
         )
@@ -1111,6 +1144,7 @@ mod tests {
             &mock_server.uri(),
             "run-action",
             None,
+            None,
             Duration::from_secs(30),
         )
         .await
@@ -1119,6 +1153,87 @@ mod tests {
         assert_eq!(
             error.to_string(),
             "Connector action 'run-action' failed with status 500 Internal Server Error: provider unavailable (errorCode=provider_error, actionId=run-action, executionId=exec-500)"
+        );
+    }
+
+
+    #[test]
+    fn connector_executor_detects_single_output_handle() {
+        assert!(connector_uses_single_output_handle(Some(&HashMap::from([(
+            HandleName::from("output"),
+            manifest_reader::manifest::OutputHandle {
+                handle: HandleName::from("output"),
+                description: None,
+                json_schema: None,
+                kind: None,
+                nullable: None,
+                is_additional: false,
+                _serialize_for_cache: false,
+            },
+        )]))));
+    }
+
+    #[tokio::test]
+    async fn connector_executor_wraps_object_data_for_single_output_handle() {
+        let outputs = parse_connector_outputs(
+            "run-action",
+            serde_json::json!({
+                "success": true,
+                "data": {
+                    "bucket": "demo",
+                    "count": 2
+                }
+            }),
+            Some(&HashMap::from([(
+                HandleName::from("output"),
+                manifest_reader::manifest::OutputHandle {
+                    handle: HandleName::from("output"),
+                    description: None,
+                    json_schema: None,
+                    kind: None,
+                    nullable: None,
+                    is_additional: false,
+                    _serialize_for_cache: false,
+                },
+            )])),
+        )
+        .unwrap();
+
+        assert_eq!(
+            outputs.get(&HandleName::from("output")),
+            Some(&serde_json::json!({
+                "bucket": "demo",
+                "count": 2
+            }))
+        );
+    }
+
+    #[tokio::test]
+    async fn connector_executor_allows_non_object_data_for_single_output_handle() {
+        let outputs = parse_connector_outputs(
+            "run-action",
+            serde_json::json!({
+                "success": true,
+                "data": ["a", "b"]
+            }),
+            Some(&HashMap::from([(
+                HandleName::from("output"),
+                manifest_reader::manifest::OutputHandle {
+                    handle: HandleName::from("output"),
+                    description: None,
+                    json_schema: None,
+                    kind: None,
+                    nullable: None,
+                    is_additional: false,
+                    _serialize_for_cache: false,
+                },
+            )])),
+        )
+        .unwrap();
+
+        assert_eq!(
+            outputs.get(&HandleName::from("output")),
+            Some(&serde_json::json!(["a", "b"]))
         );
     }
 

--- a/runtime/src/block_job/task_job.rs
+++ b/runtime/src/block_job/task_job.rs
@@ -980,7 +980,12 @@ mod tests {
             "run-action",
             serde_json::json!({
                 "success": true,
-                "data": 1
+                "message": "ok",
+                "data": 1,
+                "meta": {
+                    "executionId": "exec-1",
+                    "actionId": "run-action"
+                }
             }),
             None,
         )
@@ -997,7 +1002,12 @@ mod tests {
         let error = parse_connector_outputs(
             "run-action",
             serde_json::json!({
-                "success": true
+                "success": true,
+                "message": "ok",
+                "meta": {
+                    "executionId": "exec-1",
+                    "actionId": "run-action"
+                }
             }),
             None,
         )
@@ -1179,9 +1189,14 @@ mod tests {
             "run-action",
             serde_json::json!({
                 "success": true,
+                "message": "ok",
                 "data": {
                     "bucket": "demo",
                     "count": 2
+                },
+                "meta": {
+                    "executionId": "exec-1",
+                    "actionId": "run-action"
                 }
             }),
             Some(&HashMap::from([(
@@ -1214,7 +1229,12 @@ mod tests {
             "run-action",
             serde_json::json!({
                 "success": true,
-                "data": ["a", "b"]
+                "message": "ok",
+                "data": ["a", "b"],
+                "meta": {
+                    "executionId": "exec-1",
+                    "actionId": "run-action"
+                }
             }),
             Some(&HashMap::from([(
                 HandleName::from("output"),

--- a/runtime/src/block_job/task_job.rs
+++ b/runtime/src/block_job/task_job.rs
@@ -5,6 +5,7 @@ use manifest_meta::{
     TaskBlockExecutor,
 };
 use manifest_reader::manifest::SpawnOptions;
+use reqwest::Client;
 
 use std::collections::HashMap;
 use std::path::Path;
@@ -21,6 +22,8 @@ use utils::path::to_absolute;
 
 use super::job_handle::BlockJobHandle;
 use super::listener::{ListenerParameters, listen_to_worker};
+
+const CONNECTOR_BASE_URL_ENV_KEY: &str = "CONNECTOR_BASE_URL";
 
 pub struct TaskJobHandle {
     pub job_id: JobId,
@@ -230,6 +233,46 @@ pub fn execute_task_job(params: TaskJobParameters) -> Option<BlockJobHandle> {
                 }
             }
         }
+        TaskBlockExecutor::Connector(e) => {
+            let action_id = e.options.action.clone();
+            let scheduler_tx = shared.scheduler_tx.clone();
+            let session_id = shared.session_id.clone();
+            let job_id_clone = job_id.clone();
+            let connector_inputs = inputs.clone();
+
+            let connector_handle = tokio::spawn(async move {
+                let result = run_connector_action(&action_id, connector_inputs).await;
+
+                match result {
+                    Ok(outputs) => {
+                        scheduler_tx.send_block_event(scheduler::ReceiveMessage::BlockFinished {
+                            session_id,
+                            job_id: job_id_clone,
+                            result: Some(outputs),
+                            error: None,
+                        });
+                    }
+                    Err(error) => {
+                        scheduler_tx.send_block_event(scheduler::ReceiveMessage::BlockFinished {
+                            session_id,
+                            job_id: job_id_clone,
+                            result: None,
+                            error: Some(error.to_string()),
+                        });
+                    }
+                }
+            });
+
+            spawn_handles.push(worker_listener_handle);
+            spawn_handles.push(connector_handle);
+
+            Some(BlockJobHandle::new(TaskJobHandle {
+                job_id,
+                shared,
+                child: None,
+                spawn_handles,
+            }))
+        }
         _ => {
             shared.scheduler_tx.send_to_executor(ExecutorParams {
                 executor_name: executor.name(),
@@ -364,6 +407,98 @@ fn get_string_value_from_inputs(inputs: &Option<BlockInputs>, key: &str) -> Opti
         .as_ref()
         .and_then(|inputs| inputs.get(&HandleName::new(key.to_string())))
         .and_then(|v| v.value.as_str().map(|s| s.to_owned()))
+}
+
+async fn run_connector_action(
+    action_id: &str,
+    inputs: Option<BlockInputs>,
+) -> Result<HashMap<HandleName, serde_json::Value>> {
+    let base_url = std::env::var(CONNECTOR_BASE_URL_ENV_KEY).map_err(|_| {
+        utils::error::Error::new(&format!(
+            "{CONNECTOR_BASE_URL_ENV_KEY} is required for connector executor"
+        ))
+    })?;
+
+    run_connector_action_with_base_url(&base_url, action_id, inputs).await
+}
+
+async fn run_connector_action_with_base_url(
+    base_url: &str,
+    action_id: &str,
+    inputs: Option<BlockInputs>,
+) -> Result<HashMap<HandleName, serde_json::Value>> {
+    let url = format!(
+        "{}/v1/actions/{}",
+        base_url.trim_end_matches('/'),
+        action_id
+    );
+
+    let request_body = serde_json::json!({
+        "input": serialize_connector_inputs(inputs),
+    });
+
+    let response = Client::new()
+        .post(&url)
+        .json(&request_body)
+        .send()
+        .await
+        .map_err(|e| {
+            utils::error::Error::with_source(
+                &format!("Failed to call connector action '{action_id}' at '{url}'"),
+                Box::new(e),
+            )
+        })?;
+
+    let status = response.status();
+    if !status.is_success() {
+        let body = response.text().await.unwrap_or_default();
+        let message = if body.is_empty() {
+            format!("Connector action '{action_id}' failed with status {status}")
+        } else {
+            format!("Connector action '{action_id}' failed with status {status}: {body}")
+        };
+
+        return Err(utils::error::Error::new(&message));
+    }
+
+    let response_json = response.json::<serde_json::Value>().await.map_err(|e| {
+        utils::error::Error::with_source(
+            &format!("Failed to parse connector action '{action_id}' response as JSON"),
+            Box::new(e),
+        )
+    })?;
+
+    parse_connector_outputs(action_id, response_json)
+}
+
+fn serialize_connector_inputs(inputs: Option<BlockInputs>) -> HashMap<String, serde_json::Value> {
+    inputs
+        .unwrap_or_default()
+        .into_iter()
+        .map(|(handle, value)| (handle.to_string(), value.value.clone()))
+        .collect()
+}
+
+fn parse_connector_outputs(
+    action_id: &str,
+    response_json: serde_json::Value,
+) -> Result<HashMap<HandleName, serde_json::Value>> {
+    let data = response_json.get("data").ok_or_else(|| {
+        utils::error::Error::new(&format!(
+            "Connector action '{action_id}' response is missing data field"
+        ))
+    })?;
+
+    let outputs = data.as_object().ok_or_else(|| {
+        utils::error::Error::new(&format!(
+            "Connector action '{action_id}' response data field must be an object"
+        ))
+    })?;
+
+    Ok(outputs
+        .iter()
+        .map(|(handle, value)| (HandleName::from(handle.clone()), value.clone()))
+        .collect())
 }
 
 fn spawn(
@@ -527,4 +662,72 @@ pub fn timeout_abort(
         reporter.error(&format!("{job_id} timeout after {timeout:?}"));
         block_status.finish(job_id, None, Some("Timeout".to_owned()), None);
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use utils::output::OutputValue;
+    use wiremock::{
+        Mock, MockServer, ResponseTemplate,
+        matchers::{body_json, method, path},
+    };
+
+    #[tokio::test]
+    async fn connector_executor_posts_inputs_and_reads_data_as_outputs() {
+        let mock_server = MockServer::start().await;
+
+        let mut inputs = BlockInputs::new();
+        inputs.insert(
+            HandleName::from("message"),
+            Arc::new(OutputValue::new(serde_json::json!("hello"), true)),
+        );
+        inputs.insert(
+            HandleName::from("count"),
+            Arc::new(OutputValue::new(serde_json::json!(3), true)),
+        );
+
+        Mock::given(method("POST"))
+            .and(path("/v1/actions/run-action"))
+            .and(body_json(serde_json::json!({
+                "input": {
+                    "message": "hello",
+                    "count": 3
+                }
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": {
+                    "result": "ok",
+                    "total": 4
+                }
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let outputs =
+            run_connector_action_with_base_url(&mock_server.uri(), "run-action", Some(inputs))
+                .await
+                .unwrap();
+
+        assert_eq!(
+            outputs.get(&HandleName::from("result")),
+            Some(&serde_json::json!("ok"))
+        );
+        assert_eq!(
+            outputs.get(&HandleName::from("total")),
+            Some(&serde_json::json!(4))
+        );
+    }
+
+    #[tokio::test]
+    async fn connector_executor_requires_object_data() {
+        let error =
+            parse_connector_outputs("run-action", serde_json::json!({ "data": 1 })).unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            "Connector action 'run-action' response data field must be an object"
+        );
+    }
 }

--- a/runtime/src/block_job/task_job.rs
+++ b/runtime/src/block_job/task_job.rs
@@ -709,16 +709,24 @@ pub fn timeout_abort(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Arc;
+    use std::sync::{Arc, Mutex, OnceLock};
     use utils::output::OutputValue;
     use wiremock::{
         Mock, MockServer, ResponseTemplate,
-        matchers::{body_json, method, path},
+        matchers::{body_json, header, method, path},
     };
+
+    static CONNECTOR_ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
 
     #[tokio::test]
     async fn connector_executor_posts_inputs_and_reads_data_as_outputs() {
+        let _env_guard = CONNECTOR_ENV_LOCK
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap();
         let mock_server = MockServer::start().await;
+        let previous_connector_base_url = std::env::var_os(CONNECTOR_BASE_URL_ENV_KEY);
+        let previous_oomol_token = std::env::var_os("OOMOL_TOKEN");
 
         let mut inputs = BlockInputs::new();
         inputs.insert(
@@ -732,6 +740,7 @@ mod tests {
 
         Mock::given(method("POST"))
             .and(path("/v1/actions/run-action"))
+            .and(header("authorization", "Bearer test-token"))
             .and(body_json(serde_json::json!({
                 "input": {
                     "message": "hello",
@@ -739,22 +748,41 @@ mod tests {
                 }
             })))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "success": true,
+                "message": "ok",
                 "data": {
                     "result": "ok",
                     "total": 4
+                },
+                "meta": {
+                    "executionId": "exec-1",
+                    "actionId": "run-action"
                 }
             })))
             .mount(&mock_server)
             .await;
 
-        let outputs = run_connector_action_with_base_url(
-            &mock_server.uri(),
-            "run-action",
-            Some(inputs),
-            Duration::from_secs(30),
-        )
-        .await
-        .unwrap();
+        unsafe {
+            std::env::set_var(CONNECTOR_BASE_URL_ENV_KEY, mock_server.uri());
+            std::env::set_var("OOMOL_TOKEN", "test-token");
+        }
+
+        let outputs = run_connector_action("run-action", Some(inputs), Duration::from_secs(30)).await;
+
+        unsafe {
+            if let Some(value) = previous_connector_base_url {
+                std::env::set_var(CONNECTOR_BASE_URL_ENV_KEY, value);
+            } else {
+                std::env::remove_var(CONNECTOR_BASE_URL_ENV_KEY);
+            }
+            if let Some(value) = previous_oomol_token {
+                std::env::set_var("OOMOL_TOKEN", value);
+            } else {
+                std::env::remove_var("OOMOL_TOKEN");
+            }
+        }
+
+        let outputs = outputs.unwrap();
 
         assert_eq!(
             outputs.get(&HandleName::from("result")),
@@ -768,8 +796,14 @@ mod tests {
 
     #[tokio::test]
     async fn connector_executor_requires_object_data() {
-        let error =
-            parse_connector_outputs("run-action", serde_json::json!({ "data": 1 })).unwrap_err();
+        let error = parse_connector_outputs(
+            "run-action",
+            serde_json::json!({
+                "success": true,
+                "data": 1
+            }),
+        )
+        .unwrap_err();
 
         assert_eq!(
             error.to_string(),
@@ -779,11 +813,37 @@ mod tests {
 
     #[tokio::test]
     async fn connector_executor_requires_data_field() {
-        let error = parse_connector_outputs("run-action", serde_json::json!({})).unwrap_err();
+        let error = parse_connector_outputs(
+            "run-action",
+            serde_json::json!({
+                "success": true
+            }),
+        )
+        .unwrap_err();
 
         assert_eq!(
             error.to_string(),
             "Connector action 'run-action' response is missing data field"
+        );
+    }
+
+    #[tokio::test]
+    async fn connector_executor_reports_unsuccessful_response_message() {
+        let error = parse_connector_outputs(
+            "run-action",
+            serde_json::json!({
+                "success": false,
+                "message": "invalid auth token",
+                "data": {
+                    "ignored": true
+                }
+            }),
+        )
+        .unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            "Connector action 'run-action' failed: invalid auth token"
         );
     }
 

--- a/runtime/src/block_job/task_job.rs
+++ b/runtime/src/block_job/task_job.rs
@@ -247,12 +247,22 @@ pub fn execute_task_job(params: TaskJobParameters) -> Option<BlockJobHandle> {
             let session_id = shared.session_id.clone();
             let job_id_clone = job_id.clone();
             let connector_inputs = inputs.clone();
+            let connector_auth_token = shared.connector_auth_token.clone();
             let request_timeout =
                 Duration::from_secs(timeout.unwrap_or(DEFAULT_CONNECTOR_REQUEST_TIMEOUT_SECS));
 
             let connector_handle = tokio::spawn(async move {
-                let result =
-                    run_connector_action(&action_id, connector_inputs, request_timeout).await;
+                let result = if let Some(ref token) = connector_auth_token {
+                    run_connector_action_with_auth_token(
+                        &action_id,
+                        connector_inputs,
+                        request_timeout,
+                        Some(token),
+                    )
+                    .await
+                } else {
+                    run_connector_action(&action_id, connector_inputs, request_timeout).await
+                };
 
                 match result {
                     Ok(outputs) => {
@@ -425,13 +435,49 @@ async fn run_connector_action(
     inputs: Option<BlockInputs>,
     request_timeout: Duration,
 ) -> Result<HashMap<HandleName, serde_json::Value>> {
+    let auth_token = std::env::var("OOMOL_TOKEN")
+        .ok()
+        .map(|s| s.trim().to_owned())
+        .filter(|s| !s.is_empty());
+
+    run_connector_action_with_auth_token(
+        action_id,
+        inputs,
+        request_timeout,
+        auth_token.as_deref(),
+    )
+    .await
+}
+
+async fn run_connector_action_with_auth_token(
+    action_id: &str,
+    inputs: Option<BlockInputs>,
+    request_timeout: Duration,
+    auth_token: Option<&str>,
+) -> Result<HashMap<HandleName, serde_json::Value>> {
+    let auth_token = auth_token
+        .map(|token| token.trim().to_owned())
+        .filter(|token| !token.is_empty())
+        .or_else(|| {
+            std::env::var("OOMOL_TOKEN")
+                .ok()
+                .map(|s| s.trim().to_owned())
+                .filter(|s| !s.is_empty())
+        });
     let base_url = std::env::var(CONNECTOR_BASE_URL_ENV_KEY).map_err(|_| {
         utils::error::Error::new(&format!(
             "{CONNECTOR_BASE_URL_ENV_KEY} is required for connector executor"
         ))
     })?;
 
-    run_connector_action_with_base_url(&base_url, action_id, inputs, request_timeout).await
+    run_connector_action_with_base_url_and_auth(
+        &base_url,
+        action_id,
+        inputs,
+        request_timeout,
+        auth_token.as_deref(),
+    )
+    .await
 }
 
 async fn run_connector_action_with_base_url(
@@ -440,16 +486,45 @@ async fn run_connector_action_with_base_url(
     inputs: Option<BlockInputs>,
     request_timeout: Duration,
 ) -> Result<HashMap<HandleName, serde_json::Value>> {
+    let auth_token = std::env::var("OOMOL_TOKEN")
+        .ok()
+        .map(|s| s.trim().to_owned())
+        .filter(|s| !s.is_empty());
+
+    run_connector_action_with_base_url_and_auth(
+        base_url,
+        action_id,
+        inputs,
+        request_timeout,
+        auth_token.as_deref(),
+    )
+    .await
+}
+
+async fn run_connector_action_with_base_url_and_auth(
+    base_url: &str,
+    action_id: &str,
+    inputs: Option<BlockInputs>,
+    request_timeout: Duration,
+    auth_token: Option<&str>,
+) -> Result<HashMap<HandleName, serde_json::Value>> {
     let url = build_connector_action_url(base_url, action_id)?;
 
     let request_body = serde_json::json!({
         "input": serialize_connector_inputs(inputs),
     });
 
-    let response = connector_http_client()
+    let request = connector_http_client()
         .post(url.clone())
         .json(&request_body)
-        .timeout(request_timeout)
+        .timeout(request_timeout);
+    let request = if let Some(token) = auth_token {
+        request.bearer_auth(token)
+    } else {
+        request
+    };
+
+    let response = request
         .send()
         .await
         .map_err(|e| {
@@ -525,6 +600,26 @@ fn parse_connector_outputs(
     action_id: &str,
     response_json: serde_json::Value,
 ) -> Result<HashMap<HandleName, serde_json::Value>> {
+    let success = response_json
+        .get("success")
+        .and_then(|value| value.as_bool())
+        .ok_or_else(|| {
+            utils::error::Error::new(&format!(
+                "Connector action '{action_id}' response is missing success field"
+            ))
+        })?;
+
+    if !success {
+        let message = response_json
+            .get("message")
+            .and_then(|value| value.as_str())
+            .filter(|message| !message.trim().is_empty())
+            .unwrap_or("unknown error");
+        return Err(utils::error::Error::new(&format!(
+            "Connector action '{action_id}' failed: {message}"
+        )));
+    }
+
     let data = response_json.get("data").ok_or_else(|| {
         utils::error::Error::new(&format!(
             "Connector action '{action_id}' response is missing data field"
@@ -709,18 +804,16 @@ pub fn timeout_abort(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::{Arc, Mutex, OnceLock};
+    use std::sync::{Arc, Mutex};
     use utils::output::OutputValue;
     use wiremock::{
         Mock, MockServer, ResponseTemplate,
         matchers::{body_json, header, method, path},
     };
 
-    static CONNECTOR_ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-
     #[tokio::test]
     async fn connector_executor_posts_inputs_and_reads_data_as_outputs() {
-        let _env_guard = CONNECTOR_ENV_LOCK
+        let _env_guard = crate::CONNECTOR_ENV_LOCK
             .get_or_init(|| Mutex::new(()))
             .lock()
             .unwrap();

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -880,9 +880,7 @@ mod tests {
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
                 "success": true,
                 "message": "ok",
-                "data": {
-                    "output": "FORWARDED_OUTPUT=connector-ok"
-                },
+                "data": "FORWARDED_OUTPUT=connector-ok",
                 "meta": {
                     "executionId": "exec-1",
                     "actionId": "echo-output"

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -836,30 +836,6 @@ mod tests {
         })
     }
 
-    fn find_block_output(
-        messages: &[serde_json::Value],
-        node_id: &str,
-        handle: &str,
-    ) -> Option<serde_json::Value> {
-        messages.iter().find_map(|message| {
-            let message_node_id = message
-                .get("stacks")
-                .and_then(|stacks| stacks.as_array())
-                .and_then(|stacks| stacks.last())
-                .and_then(|level| level.get("node_id"))
-                .and_then(|node| node.as_str());
-
-            if message.get("type").and_then(|ty| ty.as_str()) == Some("BlockOutput")
-                && message_node_id == Some(node_id)
-                && message.get("handle").and_then(|value| value.as_str()) == Some(handle)
-            {
-                message.get("output").cloned()
-            } else {
-                None
-            }
-        })
-    }
-
     #[tokio::test]
     async fn connector_executor_runs_inside_a_flow_chain() {
         let _env_guard = CONNECTOR_ENV_LOCK
@@ -880,10 +856,37 @@ mod tests {
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
                 "success": true,
                 "message": "ok",
-                "data": "FORWARDED_OUTPUT=connector-ok",
+                "data": {
+                    "forwardedOutput": "connector-ok"
+                },
                 "meta": {
                     "executionId": "exec-1",
                     "actionId": "echo-output"
+                }
+            })))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/v1/actions/confirm-output"))
+            .and(header("authorization", "Bearer test-token"))
+            .and(body_json(serde_json::json!({
+                "input": {
+                    "payload": {
+                        "forwardedOutput": "connector-ok"
+                    }
+                }
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "success": true,
+                "message": "ok",
+                "data": {
+                    "confirmed": "connector-ok"
+                },
+                "meta": {
+                    "executionId": "exec-2",
+                    "actionId": "confirm-output"
                 }
             })))
             .expect(1)
@@ -939,14 +942,16 @@ mod tests {
             .expect("connector node should finish with outputs");
         assert_eq!(
             connector_result.get("output"),
-            Some(&serde_json::json!("FORWARDED_OUTPUT=connector-ok"))
+            Some(&serde_json::json!({
+                "forwardedOutput": "connector-ok"
+            }))
         );
 
-        let stdout = find_block_output(&messages, "after-connector", "stdout")
-            .unwrap_or_else(|| panic!("downstream shell node should emit stdout: {messages:?}"));
-        let stdout = stdout
-            .as_str()
-            .expect("shell stdout output should be a string");
-        assert_eq!(stdout.trim(), "connector-ok");
+        let after_connector_result = find_block_finished_result(&messages, "after-connector")
+            .expect("downstream connector node should finish with outputs");
+        assert_eq!(
+            after_connector_result.get("confirmed"),
+            Some(&serde_json::json!("connector-ok"))
+        );
     }
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -648,3 +648,304 @@ pub fn find_upstream(
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use flume::{Receiver, Sender};
+    use mainframe::{
+        MessageData,
+        reporter::{self, ReporterRxImpl, ReporterTxImpl},
+        scheduler::{self, ExecutorParameters, SchedulerRxImpl, SchedulerTxImpl},
+    };
+    use std::{
+        path::PathBuf,
+        sync::{Arc, Mutex, OnceLock},
+    };
+    use wiremock::{
+        Mock, MockServer, ResponseTemplate,
+        matchers::{body_json, header, method, path},
+    };
+
+    static CONNECTOR_ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+    struct LoopbackSchedulerTx {
+        tx: Sender<MessageData>,
+    }
+
+    #[async_trait]
+    impl SchedulerTxImpl for LoopbackSchedulerTx {
+        async fn send_block_event(&self, _session_id: &job::SessionId, data: MessageData) {
+            let _ = self.tx.send_async(data).await;
+        }
+
+        async fn send_inputs(&self, _job_id: &job::JobId, _data: MessageData) {}
+
+        async fn run_block(&self, _executor_name: &str, _data: MessageData) {}
+
+        async fn respond_block_request(
+            &self,
+            _session_id: &job::SessionId,
+            _request_id: &str,
+            _data: MessageData,
+        ) {
+        }
+
+        async fn run_service_block(&self, _executor_name: &str, _data: MessageData) {}
+
+        async fn disconnect(&self) {}
+    }
+
+    struct LoopbackSchedulerRx {
+        rx: Receiver<MessageData>,
+    }
+
+    #[async_trait]
+    impl SchedulerRxImpl for LoopbackSchedulerRx {
+        async fn recv(&mut self) -> MessageData {
+            self.rx.recv_async().await.unwrap_or_default()
+        }
+    }
+
+    struct CollectReporterTx {
+        tx: Sender<serde_json::Value>,
+    }
+
+    #[async_trait]
+    impl ReporterTxImpl for CollectReporterTx {
+        async fn send(&self, data: MessageData) {
+            if let Ok(message) = serde_json::from_slice::<serde_json::Value>(&data) {
+                let _ = self.tx.send_async(message).await;
+            }
+        }
+
+        async fn disconnect(&self) {}
+    }
+
+    struct NoopReporterRx;
+
+    impl ReporterRxImpl for NoopReporterRx {
+        fn event_loop(self) -> tokio::task::JoinHandle<()> {
+            tokio::spawn(async {})
+        }
+    }
+
+    struct TestRuntime {
+        shared: Arc<shared::Shared>,
+        scheduler_handle: tokio::task::JoinHandle<()>,
+        reporter_handle: tokio::task::JoinHandle<()>,
+        delay_abort_handle: tokio::task::JoinHandle<()>,
+        reporter_rx: Receiver<serde_json::Value>,
+    }
+
+    impl TestRuntime {
+        fn new(project_root: &PathBuf) -> Self {
+            let session_id = job::SessionId::random();
+            let (scheduler_impl_tx, scheduler_impl_rx) = flume::unbounded();
+            let (scheduler_tx, scheduler_rx) = scheduler::create(
+                LoopbackSchedulerTx {
+                    tx: scheduler_impl_tx,
+                },
+                LoopbackSchedulerRx {
+                    rx: scheduler_impl_rx,
+                },
+                None,
+                None,
+                ExecutorParameters {
+                    addr: "127.0.0.1:0".to_string(),
+                    session_id: session_id.clone(),
+                    session_dir: project_root.join(".tmp-session").display().to_string(),
+                    pass_through_env_keys: vec![],
+                    bind_paths: vec![],
+                    env_file: None,
+                    tmp_dir: std::env::temp_dir(),
+                    debug: false,
+                    wait_for_client: false,
+                },
+                project_root.display().to_string(),
+            );
+
+            let (reporter_tx, reporter_rx) = flume::unbounded();
+            let (reporter, reporter_loop) = reporter::create(
+                session_id.clone(),
+                Some(CollectReporterTx { tx: reporter_tx }),
+                Some(NoopReporterRx),
+            );
+
+            let (delay_abort_tx, delay_abort_rx) = crate::delay_abort::delay_abort();
+
+            Self {
+                shared: Arc::new(shared::Shared {
+                    session_id,
+                    address: "127.0.0.1:0".to_string(),
+                    scheduler_tx,
+                    delay_abort_tx,
+                    reporter,
+                    use_cache: false,
+                    remote_task_config: None,
+                }),
+                scheduler_handle: scheduler_rx.event_loop(),
+                reporter_handle: reporter_loop.event_loop(),
+                delay_abort_handle: delay_abort_rx.run(),
+                reporter_rx,
+            }
+        }
+
+        async fn shutdown(self) -> Receiver<serde_json::Value> {
+            self.shared.scheduler_tx.abort();
+            self.shared.reporter.abort();
+            let reporter_rx = self.reporter_rx;
+            drop(self.shared);
+            let _ = self.scheduler_handle.await;
+            let _ = self.reporter_handle.await;
+            self.delay_abort_handle.abort();
+            reporter_rx
+        }
+    }
+
+    fn project_root() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("..")
+            .canonicalize()
+            .unwrap()
+    }
+
+    fn find_block_finished_result(
+        messages: &[serde_json::Value],
+        node_id: &str,
+    ) -> Option<serde_json::Value> {
+        messages.iter().find_map(|message| {
+            let message_node_id = message
+                .get("stacks")
+                .and_then(|stacks| stacks.as_array())
+                .and_then(|stacks| stacks.last())
+                .and_then(|level| level.get("node_id"))
+                .and_then(|node| node.as_str());
+
+            if message.get("type").and_then(|ty| ty.as_str()) == Some("BlockFinished")
+                && message_node_id == Some(node_id)
+            {
+                message.get("result").cloned()
+            } else {
+                None
+            }
+        })
+    }
+
+    fn find_block_output(
+        messages: &[serde_json::Value],
+        node_id: &str,
+        handle: &str,
+    ) -> Option<serde_json::Value> {
+        messages.iter().find_map(|message| {
+            let message_node_id = message
+                .get("stacks")
+                .and_then(|stacks| stacks.as_array())
+                .and_then(|stacks| stacks.last())
+                .and_then(|level| level.get("node_id"))
+                .and_then(|node| node.as_str());
+
+            if message.get("type").and_then(|ty| ty.as_str()) == Some("BlockOutput")
+                && message_node_id == Some(node_id)
+                && message.get("handle").and_then(|value| value.as_str()) == Some(handle)
+            {
+                message.get("output").cloned()
+            } else {
+                None
+            }
+        })
+    }
+
+    #[tokio::test]
+    async fn connector_executor_runs_inside_a_flow_chain() {
+        let _env_guard = CONNECTOR_ENV_LOCK
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap();
+
+        let mock_server = MockServer::start().await;
+        let previous_oomol_token = std::env::var_os("OOMOL_TOKEN");
+        Mock::given(method("POST"))
+            .and(path("/v1/actions/echo-output"))
+            .and(header("authorization", "Bearer test-token"))
+            .and(body_json(serde_json::json!({
+                "input": {
+                    "input": "upstream-payload"
+                }
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "success": true,
+                "message": "ok",
+                "data": {
+                    "output": "FORWARDED_OUTPUT=connector-ok"
+                },
+                "meta": {
+                    "executionId": "exec-1",
+                    "actionId": "echo-output"
+                }
+            })))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let root = project_root();
+        let runtime = TestRuntime::new(&root);
+        let flow_path = root.join("tests/fixtures/connector-flow.oo.yaml");
+        let previous_connector_base_url = std::env::var_os("CONNECTOR_BASE_URL");
+
+        unsafe {
+            std::env::set_var("CONNECTOR_BASE_URL", mock_server.uri());
+            std::env::set_var("OOMOL_TOKEN", "test-token");
+        }
+
+        let run_result = run(RunArgs {
+            shared: runtime.shared.clone(),
+            block_name: flow_path.to_str().unwrap(),
+            block_reader: BlockResolver::new(),
+            path_finder: BlockPathFinder::new(root.clone(), None),
+            job_id: None,
+            nodes: None,
+            inputs: None,
+            nodes_inputs: None,
+            default_package_path: None,
+            project_data: &root,
+            pkg_data_root: &root,
+            in_layer: false,
+            vault_client: None,
+        })
+        .await;
+
+        unsafe {
+            if let Some(value) = previous_connector_base_url {
+                std::env::set_var("CONNECTOR_BASE_URL", value);
+            } else {
+                std::env::remove_var("CONNECTOR_BASE_URL");
+            }
+            if let Some(value) = previous_oomol_token {
+                std::env::set_var("OOMOL_TOKEN", value);
+            } else {
+                std::env::remove_var("OOMOL_TOKEN");
+            }
+        }
+
+        let reporter_rx = runtime.shutdown().await;
+        let messages: Vec<_> = reporter_rx.try_iter().collect();
+
+        assert!(run_result.is_ok(), "flow run failed: {run_result:?}");
+
+        let connector_result = find_block_finished_result(&messages, "connector")
+            .expect("connector node should finish with outputs");
+        assert_eq!(
+            connector_result.get("output"),
+            Some(&serde_json::json!("FORWARDED_OUTPUT=connector-ok"))
+        );
+
+        let stdout = find_block_output(&messages, "after-connector", "stdout")
+            .unwrap_or_else(|| panic!("downstream shell node should emit stdout: {messages:?}"));
+        let stdout = stdout
+            .as_str()
+            .expect("shell stdout output should be a string");
+        assert_eq!(stdout.trim(), "connector-ok");
+    }
+}

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -35,6 +35,10 @@ use crate::{
 
 const SESSION_CANCEL_INFO: &str = "Cancelled";
 
+#[cfg(test)]
+pub(crate) static CONNECTOR_ENV_LOCK: std::sync::OnceLock<std::sync::Mutex<()>> =
+    std::sync::OnceLock::new();
+
 pub struct RunArgs<'a> {
     pub shared: Arc<shared::Shared>,
     pub block_name: &'a str,
@@ -661,14 +665,12 @@ mod tests {
     };
     use std::{
         path::PathBuf,
-        sync::{Arc, Mutex, OnceLock},
+        sync::{Arc, Mutex},
     };
     use wiremock::{
         Mock, MockServer, ResponseTemplate,
         matchers::{body_json, header, method, path},
     };
-
-    static CONNECTOR_ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
 
     struct LoopbackSchedulerTx {
         tx: Sender<MessageData>,
@@ -779,6 +781,7 @@ mod tests {
                 shared: Arc::new(shared::Shared {
                     session_id,
                     address: "127.0.0.1:0".to_string(),
+                    connector_auth_token: None,
                     scheduler_tx,
                     delay_abort_tx,
                     reporter,

--- a/runtime/src/remote_task_config.rs
+++ b/runtime/src/remote_task_config.rs
@@ -1,5 +1,18 @@
 use std::collections::HashMap;
 
+pub fn resolve_auth_token(env_file_vars: &HashMap<String, String>) -> Option<String> {
+    std::env::var("OOMOL_TOKEN")
+        .ok()
+        .map(|s| s.trim().to_owned())
+        .filter(|s| !s.is_empty())
+        .or_else(|| {
+            env_file_vars
+                .get("OOMOL_TOKEN")
+                .map(|s| s.trim().to_owned())
+                .filter(|s| !s.is_empty())
+        })
+}
+
 #[derive(Debug, Clone)]
 pub struct RemoteTaskConfig {
     pub base_url: String,
@@ -34,16 +47,7 @@ impl RemoteTaskConfig {
                     .filter(|s| !s.is_empty())
             })?;
 
-        let auth_token = std::env::var("OOMOL_TOKEN")
-            .ok()
-            .map(|s| s.trim().to_owned())
-            .filter(|s| !s.is_empty())
-            .or_else(|| {
-                env_file_vars
-                    .get("OOMOL_TOKEN")
-                    .map(|s| s.trim().to_owned())
-                    .filter(|s| !s.is_empty())
-            });
+        let auth_token = resolve_auth_token(env_file_vars);
 
         let timeout_secs = cli_timeout.or_else(|| {
             std::env::var("OOCANA_REMOTE_BLOCK_TIMEOUT")

--- a/runtime/src/shared.rs
+++ b/runtime/src/shared.rs
@@ -8,6 +8,7 @@ use crate::remote_task_config::RemoteTaskConfig;
 pub struct Shared {
     pub session_id: SessionId,
     pub address: String,
+    pub connector_auth_token: Option<String>,
     pub scheduler_tx: SchedulerTx,
     pub delay_abort_tx: DelayAbortTx,
     pub reporter: ReporterTx,

--- a/tests/fixtures/connector-flow.oo.yaml
+++ b/tests/fixtures/connector-flow.oo.yaml
@@ -1,0 +1,39 @@
+name: connector-executor-chain
+nodes:
+  - node_id: before-connector
+    values:
+      - handle: input
+        value: "upstream-payload"
+
+  - node_id: connector
+    task:
+      executor:
+        name: connector
+        options:
+          action: echo-output
+      inputs_def:
+        - handle: input
+      outputs_def:
+        - handle: output
+    inputs_from:
+      - handle: input
+        from_node:
+          - node_id: before-connector
+            output_handle: input
+
+  - node_id: after-connector
+    task:
+      executor:
+        name: shell
+      inputs_def:
+        - handle: command
+        - handle: envs
+      outputs_def:
+        - handle: stdout
+    inputs_from:
+      - handle: envs
+        from_node:
+          - node_id: connector
+            output_handle: output
+      - handle: command
+        value: "printf '%s\\n' \"$FORWARDED_OUTPUT\""

--- a/tests/fixtures/connector-flow.oo.yaml
+++ b/tests/fixtures/connector-flow.oo.yaml
@@ -24,16 +24,15 @@ nodes:
   - node_id: after-connector
     task:
       executor:
-        name: shell
+        name: connector
+        options:
+          action: confirm-output
       inputs_def:
-        - handle: command
-        - handle: envs
+        - handle: payload
       outputs_def:
-        - handle: stdout
+        - handle: confirmed
     inputs_from:
-      - handle: envs
+      - handle: payload
         from_node:
           - node_id: connector
             output_handle: output
-      - handle: command
-        value: "printf '%s\\n' \"$FORWARDED_OUTPUT\""


### PR DESCRIPTION
## Summary
- add a new `connector` task executor with `options.action`
- execute connector blocks in runtime by POSTing to `$CONNECTOR_BASE_URL/v1/actions/{action}` with the block inputs as `input`
- map response `data` fields back to block outputs and add executor parsing/runtime tests

## Testing
- cargo test -p manifest_reader deserialize_connector_executor
- cargo test -p runtime connector_executor
- cargo test -p oocana --no-run