### PR TITLE
chore: stabilize formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,34 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.rs]
+indent_style = space
+indent_size = 4
+
+[*.json]
+indent_style = space
+indent_size = 2
+
+[*.jsonc]
+indent_style = space
+indent_size = 2
+
+[*.yml]
+indent_style = space
+indent_size = 2
+
+[*.yaml]
+indent_style = space
+indent_size = 2
+
+[*.toml]
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -53,7 +53,9 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           rustflags: ""
-          components: clippy
+          components: clippy, rustfmt
+      - name: Rustfmt
+        run: cargo fmt --all -- --check
       - name: Clippy
         run: cargo clippy --workspace -- -W clippy::all -D warnings
       - name: Start MQTT Broker

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -31,6 +31,18 @@
     "manifest_meta"
   ],
   "rust-analyzer.runnables.extraTestBinaryArgs": ["--nocapture"],
+  "rust-analyzer.rustfmt.overrideCommand": [
+    "rustup",
+    "run",
+    "1.88.0",
+    "rustfmt",
+    "--edition",
+    "2024",
+    "--style-edition",
+    "2024",
+    "--emit",
+    "stdout"
+  ],
   "git.branchProtection": ["main"],
   "git.branchProtectionPrompt": "alwaysCommitToNewBranch",
   "git.branchRandomName.enable": true

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -35,13 +35,7 @@
     "rustup",
     "run",
     "1.88.0",
-    "rustfmt",
-    "--edition",
-    "2024",
-    "--style-edition",
-    "2024",
-    "--emit",
-    "stdout"
+    "rustfmt"
   ],
   "git.branchProtection": ["main"],
   "git.branchProtectionPrompt": "alwaysCommitToNewBranch",

--- a/layer/src/injection_store.rs
+++ b/layer/src/injection_store.rs
@@ -37,8 +37,7 @@ pub fn injection_store_path() -> Result<PathBuf> {
             version: env!("CARGO_PKG_VERSION").to_string(),
             flow_injection: HashMap::new(),
         };
-        serde_json::to_writer(writer, &store)
-            .map_err(|e| format!("Failed to serialize: {e:?}"))?;
+        serde_json::to_writer(writer, &store).map_err(|e| format!("Failed to serialize: {e:?}"))?;
     }
 
     Ok(file)

--- a/layer/src/layer_settings.rs
+++ b/layer/src/layer_settings.rs
@@ -29,8 +29,7 @@ pub fn layer_setting_file() -> Result<PathBuf> {
         let store = LayerSettings {
             base_rootfs: vec![],
         };
-        serde_json::to_writer(writer, &store)
-            .map_err(|e| format!("Failed to serialize: {e:?}"))?;
+        serde_json::to_writer(writer, &store).map_err(|e| format!("Failed to serialize: {e:?}"))?;
     }
 
     Ok(file)
@@ -49,9 +48,7 @@ pub fn load_base_rootfs() -> Result<Vec<String>> {
                 .filter(|s| !s.is_empty())
                 .cloned()
                 .collect()),
-            Err(e) => Err(Error::new(&format!(
-                "Failed to load_package_store: {e:?}"
-            ))),
+            Err(e) => Err(Error::new(&format!("Failed to load_package_store: {e:?}"))),
         }
     } else {
         Err(Error::new("Failed to open file"))

--- a/mainframe/src/reporter/block_reporter.rs
+++ b/mainframe/src/reporter/block_reporter.rs
@@ -113,10 +113,7 @@ impl BlockReporterTx {
                 "session_id".into(),
                 Value::String(self.tx.session_id.to_string()),
             );
-            obj.insert(
-                "job_id".into(),
-                Value::String(self.job_id.to_string()),
-            );
+            obj.insert("job_id".into(), Value::String(self.job_id.to_string()));
             obj.insert(
                 "block_path".into(),
                 self.block_path

--- a/mainframe/src/scheduler.rs
+++ b/mainframe/src/scheduler.rs
@@ -630,7 +630,10 @@ impl SchedulerTx {
     }
 
     pub fn register_subscriber(&self, job_id: JobId, sender: Sender<ReceiveMessage>) {
-        if let Err(e) = self.tx.send(SchedulerCommand::RegisterSubscriber(job_id, sender)) {
+        if let Err(e) = self
+            .tx
+            .send(SchedulerCommand::RegisterSubscriber(job_id, sender))
+        {
             warn!("Scheduler register subscriber failed: {e}");
         }
     }
@@ -1414,8 +1417,8 @@ where
                                 })
                                 .unwrap();
 
-                                if let Err(e) = tx_clone
-                                    .send(SchedulerCommand::ReceiveMessage(data))
+                                if let Err(e) =
+                                    tx_clone.send(SchedulerCommand::ReceiveMessage(data))
                                 {
                                     warn!("Scheduler send listener timeout failed: {e}");
                                 }
@@ -1515,8 +1518,12 @@ where
                                     // Handle block request
                                     let job_id = request.job_id().clone();
                                     if let Some(sender) = subscribers.get(&job_id) {
-                                        if let Err(e) = sender.send(ReceiveMessage::BlockRequest(request)) {
-                                            warn!("Scheduler send block request to subscriber failed, removing: {e}");
+                                        if let Err(e) =
+                                            sender.send(ReceiveMessage::BlockRequest(request))
+                                        {
+                                            warn!(
+                                                "Scheduler send block request to subscriber failed, removing: {e}"
+                                            );
                                             subscribers.remove(&job_id);
                                         }
                                     } else {
@@ -1527,7 +1534,9 @@ where
                                     if let Some(job_id) = msg.job_id().cloned() {
                                         if let Some(sender) = subscribers.get(&job_id) {
                                             if let Err(e) = sender.send(msg) {
-                                                warn!("Scheduler send message to subscriber failed, removing: {e}");
+                                                warn!(
+                                                    "Scheduler send message to subscriber failed, removing: {e}"
+                                                );
                                                 subscribers.remove(&job_id);
                                             }
                                         }

--- a/manifest_meta/src/block_resolver.rs
+++ b/manifest_meta/src/block_resolver.rs
@@ -1,7 +1,7 @@
 use manifest_reader::{
     manifest::{self, InputHandles},
     path_finder::BlockPathFinder,
-    reader::{read_block_metadata, read_task_block, BlockMetadata},
+    reader::{BlockMetadata, read_block_metadata, read_task_block},
 };
 use std::{
     collections::HashMap,

--- a/remote_job_client/src/mock.rs
+++ b/remote_job_client/src/mock.rs
@@ -124,11 +124,7 @@ async fn get_task_detail(
         progress: progress(task),
         created_at: 0.0,
         start_time: if status != "queued" { Some(0.0) } else { None },
-        end_time: if status == "success" {
-            Some(0.0)
-        } else {
-            None
-        },
+        end_time: if status == "success" { Some(0.0) } else { None },
         failed_message: None,
     };
 
@@ -179,13 +175,13 @@ async fn get_task_logs(
 ) -> impl IntoResponse {
     let guard = tasks.lock().unwrap();
     let Some(task) = guard.get(&task_id) else {
-        return (StatusCode::NOT_FOUND, Json(serde_json::json!({ "logs": [] })));
+        return (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({ "logs": [] })),
+        );
     };
 
-    let page: u32 = params
-        .get("page")
-        .and_then(|p| p.parse().ok())
-        .unwrap_or(1);
+    let page: u32 = params.get("page").and_then(|p| p.parse().ok()).unwrap_or(1);
 
     let status = current_status(task);
     eprintln!("[mock] GET /tasks/{task_id}/logs?page={page} -> status={status}");
@@ -271,14 +267,8 @@ pub fn start(port: u16) -> MockServer {
             let app = Router::new()
                 .route("/v3/users/me/tasks", post(create_task))
                 .route("/v3/users/me/tasks/{task_id}", get(get_task_detail))
-                .route(
-                    "/v3/users/me/tasks/{task_id}/result",
-                    get(get_task_result),
-                )
-                .route(
-                    "/v3/users/me/tasks/{task_id}/logs",
-                    get(get_task_logs),
-                )
+                .route("/v3/users/me/tasks/{task_id}/result", get(get_task_result))
+                .route("/v3/users/me/tasks/{task_id}/logs", get(get_task_logs))
                 .with_state(tasks);
 
             let addr = format!("127.0.0.1:{port}");
@@ -287,7 +277,9 @@ pub fn start(port: u16) -> MockServer {
                 .unwrap_or_else(|e| panic!("failed to bind {addr}: {e}"));
 
             axum::serve(listener, app)
-                .with_graceful_shutdown(async { let _ = shutdown_rx.await; })
+                .with_graceful_shutdown(async {
+                    let _ = shutdown_rx.await;
+                })
                 .await
                 .unwrap();
         });

--- a/runtime/src/block_job/listener.rs
+++ b/runtime/src/block_job/listener.rs
@@ -190,9 +190,8 @@ pub fn listen_to_worker(params: ListenerParameters) -> tokio::task::JoinHandle<(
                     reason,
                     ..
                 } => {
-                    let msg = reason.unwrap_or(format!(
-                        "Executor {executor_name} exit with code {code}"
-                    ));
+                    let msg =
+                        reason.unwrap_or(format!("Executor {executor_name} exit with code {code}"));
 
                     reporter.finished(None, Some(msg.clone()));
                     block_status.error(msg);

--- a/runtime/src/block_job/remote_block_job.rs
+++ b/runtime/src/block_job/remote_block_job.rs
@@ -4,8 +4,8 @@ use std::sync::Arc;
 use job::{BlockInputs, BlockJobStacks, JobId};
 use mainframe::reporter::BlockReporterTx;
 use manifest_meta::{HandleName, TaskBlock};
-use tracing::warn;
 use remote_job_client::{CreateTaskRequest, RemoteJobClient, TaskStatus};
+use tracing::warn;
 use utils::output::OutputValue;
 
 use crate::block_status::BlockStatusTx;
@@ -111,8 +111,7 @@ async fn poll_logs(
                                 }
                             }
                             Some("BlockOutputs") => {
-                                if let Some(obj) = item.get("outputs").and_then(|o| o.as_object())
-                                {
+                                if let Some(obj) = item.get("outputs").and_then(|o| o.as_object()) {
                                     let outputs = obj
                                         .iter()
                                         .map(|(k, v)| {
@@ -131,10 +130,8 @@ async fn poll_logs(
                                         .get("error")
                                         .and_then(|e| e.as_str())
                                         .map(|s| s.to_owned());
-                                    finish_result = item
-                                        .get("result")
-                                        .and_then(|r| r.as_object())
-                                        .map(|obj| {
+                                    finish_result =
+                                        item.get("result").and_then(|r| r.as_object()).map(|obj| {
                                             obj.iter()
                                                 .map(|(k, v)| {
                                                     (
@@ -163,7 +160,12 @@ async fn poll_logs(
                     }
 
                     if should_finish {
-                        ctx.block_status.finish(ctx.job_id.clone(), finish_result, finish_error, None);
+                        ctx.block_status.finish(
+                            ctx.job_id.clone(),
+                            finish_result,
+                            finish_error,
+                            None,
+                        );
                         *finished = true;
                     }
                     *logs_sent_on_page += 1;
@@ -305,10 +307,7 @@ pub fn execute_remote_block_job(params: RemoteBlockJobParameters) -> Option<Bloc
             }
         };
 
-        reporter_clone.log(
-            &format!("Remote task created: {task_id}"),
-            "remote_task",
-        );
+        reporter_clone.log(&format!("Remote task created: {task_id}"), "remote_task");
 
         // Logs polling state
         let mut logs_page: u32 = 1;
@@ -329,9 +328,7 @@ pub fn execute_remote_block_job(params: RemoteBlockJobParameters) -> Option<Bloc
 
             if let Some(dl) = deadline {
                 if tokio::time::Instant::now() >= dl {
-                    let msg = format!(
-                        "Remote task {task_id} timed out after {timeout_secs}s"
-                    );
+                    let msg = format!("Remote task {task_id} timed out after {timeout_secs}s");
                     reporter_clone.finished(None, Some(msg.clone()));
                     block_status_clone.finish(job_id_clone, None, Some(msg), None);
                     return;

--- a/runtime/src/block_job/task_job.rs
+++ b/runtime/src/block_job/task_job.rs
@@ -540,15 +540,12 @@ async fn run_connector_action_with_base_url_and_auth(
         request
     };
 
-    let response = request
-        .send()
-        .await
-        .map_err(|e| {
-            utils::error::Error::with_source(
-                &format!("Failed to call connector action '{action_id}' at '{url}'"),
-                Box::new(e),
-            )
-        })?;
+    let response = request.send().await.map_err(|e| {
+        utils::error::Error::with_source(
+            &format!("Failed to call connector action '{action_id}' at '{url}'"),
+            Box::new(e),
+        )
+    })?;
 
     let status = response.status();
     if !status.is_success() {
@@ -607,18 +604,16 @@ fn truncate_connector_error_body(body: &str) -> String {
     }
 }
 
-fn format_connector_http_error(
-    action_id: &str,
-    status: reqwest::StatusCode,
-    body: &str,
-) -> String {
+fn format_connector_http_error(action_id: &str, status: reqwest::StatusCode, body: &str) -> String {
     if body.is_empty() {
         return format!("Connector action '{action_id}' failed with status {status}");
     }
 
     if let Ok(response_json) = serde_json::from_str::<serde_json::Value>(body) {
         if let Some(details) = format_connector_error_details(&response_json) {
-            return format!("Connector action '{action_id}' failed with status {status}: {details}");
+            return format!(
+                "Connector action '{action_id}' failed with status {status}: {details}"
+            );
         }
     }
 
@@ -689,8 +684,8 @@ fn parse_connector_outputs(
         })?;
 
     if !success {
-        let message =
-            format_connector_error_details(&response_json).unwrap_or_else(|| "unknown error".to_owned());
+        let message = format_connector_error_details(&response_json)
+            .unwrap_or_else(|| "unknown error".to_owned());
         return Err(utils::error::Error::new(&format!(
             "Connector action '{action_id}' failed: {message}"
         )));
@@ -1166,21 +1161,22 @@ mod tests {
         );
     }
 
-
     #[test]
     fn connector_executor_detects_single_output_handle() {
-        assert!(connector_uses_single_output_handle(Some(&HashMap::from([(
-            HandleName::from("output"),
-            manifest_reader::manifest::OutputHandle {
-                handle: HandleName::from("output"),
-                description: None,
-                json_schema: None,
-                kind: None,
-                nullable: None,
-                is_additional: false,
-                _serialize_for_cache: false,
-            },
-        )]))));
+        assert!(connector_uses_single_output_handle(Some(&HashMap::from([
+            (
+                HandleName::from("output"),
+                manifest_reader::manifest::OutputHandle {
+                    handle: HandleName::from("output"),
+                    description: None,
+                    json_schema: None,
+                    kind: None,
+                    nullable: None,
+                    is_additional: false,
+                    _serialize_for_cache: false,
+                },
+            )
+        ]))));
     }
 
     #[tokio::test]

--- a/runtime/src/block_status.rs
+++ b/runtime/src/block_status.rs
@@ -1,12 +1,12 @@
 use std::{collections::HashMap, sync::Arc};
 
 use flume::{Receiver, Sender};
-use tracing::warn;
 use job::JobId;
 use mainframe::{
     reporter::ErrorDetail,
     scheduler::{BlockRequest, OutputOptions},
 };
+use tracing::warn;
 use utils::output::OutputValue;
 
 use manifest_meta::HandleName;

--- a/runtime/src/flow_job/node_input_values.rs
+++ b/runtime/src/flow_job/node_input_values.rs
@@ -186,12 +186,10 @@ impl NodeInputValues {
                 .map_err(|e| format!("failed to serialize {e}"))?;
 
             if let Some(parent) = path.parent() {
-                std::fs::create_dir_all(parent)
-                    .map_err(|e| format!("failed to create dir {e}"))?;
+                std::fs::create_dir_all(parent).map_err(|e| format!("failed to create dir {e}"))?;
             }
 
-            let mut file =
-                File::create(path).map_err(|e| format!("failed to create file {e}"))?;
+            let mut file = File::create(path).map_err(|e| format!("failed to create file {e}"))?;
             file.write_all(json_string.as_bytes())
                 .map_err(|e| format!("failed to write file {e}"))?;
         }

--- a/tests/test_remote_task.rs
+++ b/tests/test_remote_task.rs
@@ -1,8 +1,8 @@
 use assert_cmd::prelude::*;
 use std::process::{Command, Output, Stdio};
 
-use serde_json::Value;
 use remote_job_client::mock;
+use serde_json::Value;
 
 fn oocana_cmd() -> Command {
     let mut cmd = Command::cargo_bin("oocana").unwrap();

--- a/utils/src/config/app.rs
+++ b/utils/src/config/app.rs
@@ -42,8 +42,8 @@ pub fn load_config<P: AsRef<Path>>(file: Option<P>) -> Result<AppConfig, String>
 
         // 如果展开后还是相对路径，拼接当前目录
         if expanded.is_relative() {
-            let mut current_dir = std::env::current_dir()
-                .map_err(|e| format!("Failed to get current dir: {e:?}"))?;
+            let mut current_dir =
+                std::env::current_dir().map_err(|e| format!("Failed to get current dir: {e:?}"))?;
             current_dir.push(expanded);
             current_dir
         } else {

--- a/utils/tests/test.rs
+++ b/utils/tests/test.rs
@@ -11,10 +11,7 @@ mod tests {
         let home_dir = dirs::home_dir().unwrap().to_string_lossy().to_string();
         let global = config.global;
 
-        assert_eq!(
-            global.store_dir,
-            format!("{home_dir}/.oomol-studio/oocana")
-        );
+        assert_eq!(global.store_dir, format!("{home_dir}/.oomol-studio/oocana"));
         assert_eq!(global.oocana_dir, format!("{home_dir}/.oocana"));
     }
 
@@ -29,10 +26,7 @@ mod tests {
         let config = config.unwrap();
         let home_dir = dirs::home_dir().unwrap().to_string_lossy().to_string();
         let global = config.global.clone();
-        assert_eq!(
-            global.store_dir,
-            format!("{home_dir}/.oomol-studio/oocana")
-        );
+        assert_eq!(global.store_dir, format!("{home_dir}/.oomol-studio/oocana"));
         assert_eq!(global.oocana_dir, format!("{home_dir}/.oocana"));
         assert_eq!(global.env_file, Some(format!("{home_dir}/.oocana/.env")));
         assert_eq!(


### PR DESCRIPTION
## Summary
- run the workspace through the pinned `rustfmt` toolchain once to remove accumulated style drift
- pin editor formatting to `rustup run 1.88.0 rustfmt` in VS Code so format-on-save uses the repository toolchain
- add `cargo fmt --all -- --check` to CI and commit a root `.editorconfig` for cross-editor whitespace consistency

## Verification
- `cargo +1.88.0 fmt --all -- --check`
- `cargo test --workspace --exclude layer` *(fails in existing `tests/test_remote_task.rs::remote_task_flow` with `ConnectionRefused`; unrelated to these formatting-only changes)*
