### PR TITLE
fix(layer): skip ovmlayer probe when unavailable

### DIFF
--- a/layer/src/lib.rs
+++ b/layer/src/lib.rs
@@ -26,9 +26,20 @@ pub use runtime_layer::{InjectionParams, RuntimeLayer, create_runtime_layer};
 use crate::ovmlayer::is_root;
 
 fn has_ovmlayer_binary() -> bool {
+    use std::os::unix::fs::PermissionsExt;
+    
     env::var_os("PATH")
-        .map(|paths| env::split_paths(&paths).any(|path| path.join("ovmlayer").is_file()))
+        .map(|paths| {
+            env::split_paths(&paths).any(|dir| {
+                let candidate = dir.join("ovmlayer");
+                candidate.is_file()
+                    && std::fs::metadata(&candidate)
+                        .map(|m| m.permissions().mode() & 0o111 != 0)
+                        .unwrap_or(false)
+            })
+        })
         .unwrap_or(false)
+}
 }
 
 pub fn feature_enabled() -> bool {

--- a/layer/src/lib.rs
+++ b/layer/src/lib.rs
@@ -27,7 +27,7 @@ use crate::ovmlayer::is_root;
 
 fn has_ovmlayer_binary() -> bool {
     use std::os::unix::fs::PermissionsExt;
-    
+
     env::var_os("PATH")
         .map(|paths| {
             env::split_paths(&paths).any(|dir| {
@@ -39,7 +39,6 @@ fn has_ovmlayer_binary() -> bool {
             })
         })
         .unwrap_or(false)
-}
 }
 
 pub fn feature_enabled() -> bool {

--- a/layer/src/lib.rs
+++ b/layer/src/lib.rs
@@ -9,7 +9,7 @@ mod package_store;
 mod registry_layer_store;
 mod runtime_layer;
 
-use std::{env, process::Command};
+use std::process::Command;
 
 pub use ovmlayer::BindPath;
 pub use package_layer::{import_package_layer, move_package_layer};
@@ -25,12 +25,13 @@ pub use runtime_layer::{InjectionParams, RuntimeLayer, create_runtime_layer};
 
 use crate::ovmlayer::is_root;
 
+#[cfg(target_os = "linux")]
 fn has_ovmlayer_binary() -> bool {
     use std::os::unix::fs::PermissionsExt;
 
-    env::var_os("PATH")
+    std::env::var_os("PATH")
         .map(|paths| {
-            env::split_paths(&paths).any(|dir| {
+            std::env::split_paths(&paths).any(|dir| {
                 let candidate = dir.join("ovmlayer");
                 candidate.is_file()
                     && std::fs::metadata(&candidate)
@@ -39,6 +40,11 @@ fn has_ovmlayer_binary() -> bool {
             })
         })
         .unwrap_or(false)
+}
+
+#[cfg(not(target_os = "linux"))]
+fn has_ovmlayer_binary() -> bool {
+    false
 }
 
 pub fn feature_enabled() -> bool {

--- a/layer/src/lib.rs
+++ b/layer/src/lib.rs
@@ -9,7 +9,7 @@ mod package_store;
 mod registry_layer_store;
 mod runtime_layer;
 
-use std::process::Command;
+use std::{env, process::Command};
 
 pub use ovmlayer::BindPath;
 pub use package_layer::{import_package_layer, move_package_layer};
@@ -25,7 +25,17 @@ pub use runtime_layer::{InjectionParams, RuntimeLayer, create_runtime_layer};
 
 use crate::ovmlayer::is_root;
 
+fn has_ovmlayer_binary() -> bool {
+    env::var_os("PATH")
+        .map(|paths| env::split_paths(&paths).any(|path| path.join("ovmlayer").is_file()))
+        .unwrap_or(false)
+}
+
 pub fn feature_enabled() -> bool {
+    if !cfg!(target_os = "linux") || !has_ovmlayer_binary() {
+        return false;
+    }
+
     if is_root() {
         let mut cmd = Command::new("ovmlayer");
         cmd.arg("test");


### PR DESCRIPTION
## Summary
- return false for layer support checks on non-Linux platforms
- return false when ovmlayer is not present in PATH
- only run the existing ovmlayer test system probe when those preconditions are met

## Why
Running oocana in environments without ovmlayer could block during layer probing before flow execution started. This keeps the probe on the fast path for unsupported environments and avoids invoking sudo or ovmlayer when it cannot succeed.

## Verification
- cargo fmt --all
- cargo test -p layer test_feature_enabled
- cargo check -p layer