### PR TITLE
feat(connector): support OOCANA connector base URL config

### DIFF
--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -140,6 +140,11 @@ enum Commands {
         )]
         remote_block_url: Option<String>,
         #[arg(
+            help = "Connector API base URL. Overrides OOCANA_CONNECTOR_BASE_URL env var.",
+            long
+        )]
+        connector_base_url: Option<String>,
+        #[arg(
             help = "Timeout in seconds for remote block execution. Overrides OOCANA_REMOTE_BLOCK_TIMEOUT env var. Default is 1800 (30 minutes). Use 0 to disable timeout and poll indefinitely.",
             long
         )]
@@ -256,6 +261,7 @@ pub fn cli_match() -> Result<()> {
             project_data,
             report_to_console,
             remote_block_url,
+            connector_base_url,
             remote_block_timeout,
         } => {
             let bind_paths = load_bind_paths(bind_paths, bind_path_file);
@@ -309,6 +315,7 @@ pub fn cli_match() -> Result<()> {
                 pkg_data_root: &PathBuf::from(pkg_data_root),
                 report_to_console: report_to_console.to_owned(),
                 remote_block_url: remote_block_url.to_owned(),
+                connector_base_url: connector_base_url.to_owned(),
                 remote_block_timeout: remote_block_timeout.to_owned(),
             })?
         }
@@ -324,4 +331,33 @@ pub fn cli_match() -> Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn run_command_parses_connector_base_url() {
+        let cli = Cli::try_parse_from([
+            "oocana",
+            "run",
+            "tests/fixtures/connector-flow.oo.yaml",
+            "--connector-base-url",
+            "https://connector.example",
+        ])
+        .expect("cli should parse connector-base-url");
+
+        match cli.command {
+            Commands::Run {
+                connector_base_url, ..
+            } => {
+                assert_eq!(
+                    connector_base_url.as_deref(),
+                    Some("https://connector.example")
+                );
+            }
+            other => panic!("expected run command, got {other:?}"),
+        }
+    }
 }

--- a/one_shot/src/one_shot.rs
+++ b/one_shot/src/one_shot.rs
@@ -95,6 +95,7 @@ pub struct BlockArgs<'a> {
     pub pkg_data_root: &'a PathBuf,
     pub report_to_console: bool,
     pub remote_block_url: Option<String>,
+    pub connector_base_url: Option<String>,
     pub remote_block_timeout: Option<u64>,
 }
 
@@ -122,6 +123,7 @@ async fn run_block_async(block_args: BlockArgs<'_>) -> Result<()> {
         pkg_data_root,
         report_to_console,
         remote_block_url,
+        connector_base_url,
         remote_block_timeout,
     } = block_args;
     let session_id = SessionId::new(session);
@@ -304,6 +306,10 @@ async fn run_block_async(block_args: BlockArgs<'_>) -> Result<()> {
     let shared = Arc::new(runtime::shared::Shared {
         session_id: session_id.clone(),
         address: addr.to_string(),
+        connector_base_url: runtime::remote_task_config::resolve_connector_base_url(
+            connector_base_url.as_deref(),
+            &env_file_vars,
+        ),
         connector_auth_token: runtime::remote_task_config::resolve_auth_token(&env_file_vars),
         scheduler_tx: scheduler_tx.clone(),
         delay_abort_tx,

--- a/runtime/src/block_job/task_job.rs
+++ b/runtime/src/block_job/task_job.rs
@@ -24,7 +24,7 @@ use utils::path::to_absolute;
 use super::job_handle::BlockJobHandle;
 use super::listener::{ListenerParameters, listen_to_worker};
 
-const CONNECTOR_BASE_URL_ENV_KEY: &str = "CONNECTOR_BASE_URL";
+const OOCANA_CONNECTOR_BASE_URL_ENV_KEY: &str = "OOCANA_CONNECTOR_BASE_URL";
 const DEFAULT_CONNECTOR_REQUEST_TIMEOUT_SECS: u64 = 30;
 const CONNECTOR_ERROR_BODY_LIMIT: usize = 512;
 
@@ -246,6 +246,7 @@ pub fn execute_task_job(params: TaskJobParameters) -> Option<BlockJobHandle> {
             let scheduler_tx = shared.scheduler_tx.clone();
             let session_id = shared.session_id.clone();
             let job_id_clone = job_id.clone();
+            let connector_base_url = shared.connector_base_url.clone();
             let connector_inputs = inputs.clone();
             let connector_outputs_def = outputs_def.clone();
             let connector_auth_token = shared.connector_auth_token.clone();
@@ -253,24 +254,15 @@ pub fn execute_task_job(params: TaskJobParameters) -> Option<BlockJobHandle> {
                 Duration::from_secs(timeout.unwrap_or(DEFAULT_CONNECTOR_REQUEST_TIMEOUT_SECS));
 
             let connector_handle = tokio::spawn(async move {
-                let result = if let Some(ref token) = connector_auth_token {
-                    run_connector_action_with_auth_token(
-                        &action_id,
-                        connector_inputs,
-                        connector_outputs_def,
-                        request_timeout,
-                        Some(token),
-                    )
-                    .await
-                } else {
-                    run_connector_action(
-                        &action_id,
-                        connector_inputs,
-                        connector_outputs_def,
-                        request_timeout,
-                    )
-                    .await
-                };
+                let result = run_connector_action_with_configuration(
+                    &action_id,
+                    connector_inputs,
+                    connector_outputs_def,
+                    request_timeout,
+                    connector_base_url.as_deref(),
+                    connector_auth_token.as_deref(),
+                )
+                .await;
 
                 match result {
                     Ok(outputs) => {
@@ -438,32 +430,30 @@ fn get_string_value_from_inputs(inputs: &Option<BlockInputs>, key: &str) -> Opti
         .and_then(|v| v.value.as_str().map(|s| s.to_owned()))
 }
 
+#[cfg(test)]
 async fn run_connector_action(
     action_id: &str,
     inputs: Option<BlockInputs>,
     outputs_def: Option<OutputHandles>,
     request_timeout: Duration,
 ) -> Result<HashMap<HandleName, serde_json::Value>> {
-    let auth_token = std::env::var("OOMOL_TOKEN")
-        .ok()
-        .map(|s| s.trim().to_owned())
-        .filter(|s| !s.is_empty());
-
-    run_connector_action_with_auth_token(
+    run_connector_action_with_configuration(
         action_id,
         inputs,
         outputs_def,
         request_timeout,
-        auth_token.as_deref(),
+        None,
+        None,
     )
     .await
 }
 
-async fn run_connector_action_with_auth_token(
+async fn run_connector_action_with_configuration(
     action_id: &str,
     inputs: Option<BlockInputs>,
     outputs_def: Option<OutputHandles>,
     request_timeout: Duration,
+    base_url: Option<&str>,
     auth_token: Option<&str>,
 ) -> Result<HashMap<HandleName, serde_json::Value>> {
     let auth_token = auth_token
@@ -475,11 +465,21 @@ async fn run_connector_action_with_auth_token(
                 .map(|s| s.trim().to_owned())
                 .filter(|s| !s.is_empty())
         });
-    let base_url = std::env::var(CONNECTOR_BASE_URL_ENV_KEY).map_err(|_| {
-        utils::error::Error::new(&format!(
-            "{CONNECTOR_BASE_URL_ENV_KEY} is required for connector executor"
-        ))
-    })?;
+    let base_url = base_url
+        .map(str::trim)
+        .filter(|url| !url.is_empty())
+        .map(|url| url.to_owned())
+        .or_else(|| {
+            std::env::var(OOCANA_CONNECTOR_BASE_URL_ENV_KEY)
+                .ok()
+                .map(|url| url.trim().to_owned())
+                .filter(|url| !url.is_empty())
+        })
+        .ok_or_else(|| {
+            utils::error::Error::new(&format!(
+                "{OOCANA_CONNECTOR_BASE_URL_ENV_KEY} is required for connector executor"
+            ))
+        })?;
 
     run_connector_action_with_base_url_and_auth(
         &base_url,
@@ -568,7 +568,7 @@ async fn run_connector_action_with_base_url_and_auth(
 fn build_connector_action_url(base_url: &str, action_id: &str) -> Result<Url> {
     let mut url = Url::parse(base_url).map_err(|e| {
         utils::error::Error::with_source(
-            &format!("Invalid {CONNECTOR_BASE_URL_ENV_KEY}: '{base_url}'"),
+            &format!("Invalid {OOCANA_CONNECTOR_BASE_URL_ENV_KEY}: '{base_url}'"),
             Box::new(e),
         )
     })?;
@@ -576,7 +576,7 @@ fn build_connector_action_url(base_url: &str, action_id: &str) -> Result<Url> {
     {
         let mut segments = url.path_segments_mut().map_err(|_| {
             utils::error::Error::new(&format!(
-                "Invalid {CONNECTOR_BASE_URL_ENV_KEY}: '{base_url}'"
+                "Invalid {OOCANA_CONNECTOR_BASE_URL_ENV_KEY}: '{base_url}'"
             ))
         })?;
         segments.pop_if_empty();
@@ -899,7 +899,7 @@ mod tests {
             .lock()
             .unwrap();
         let mock_server = MockServer::start().await;
-        let previous_connector_base_url = std::env::var_os(CONNECTOR_BASE_URL_ENV_KEY);
+        let previous_connector_base_url = std::env::var_os(OOCANA_CONNECTOR_BASE_URL_ENV_KEY);
         let previous_oomol_token = std::env::var_os("OOMOL_TOKEN");
 
         let mut inputs = BlockInputs::new();
@@ -937,7 +937,7 @@ mod tests {
             .await;
 
         unsafe {
-            std::env::set_var(CONNECTOR_BASE_URL_ENV_KEY, mock_server.uri());
+            std::env::set_var(OOCANA_CONNECTOR_BASE_URL_ENV_KEY, mock_server.uri());
             std::env::set_var("OOMOL_TOKEN", "test-token");
         }
 
@@ -946,9 +946,9 @@ mod tests {
 
         unsafe {
             if let Some(value) = previous_connector_base_url {
-                std::env::set_var(CONNECTOR_BASE_URL_ENV_KEY, value);
+                std::env::set_var(OOCANA_CONNECTOR_BASE_URL_ENV_KEY, value);
             } else {
-                std::env::remove_var(CONNECTOR_BASE_URL_ENV_KEY);
+                std::env::remove_var(OOCANA_CONNECTOR_BASE_URL_ENV_KEY);
             }
             if let Some(value) = previous_oomol_token {
                 std::env::set_var("OOMOL_TOKEN", value);
@@ -966,6 +966,55 @@ mod tests {
         assert_eq!(
             outputs.get(&HandleName::from("total")),
             Some(&serde_json::json!(4))
+        );
+    }
+
+    #[tokio::test]
+    async fn connector_executor_uses_explicit_base_url_configuration() {
+        let mock_server = MockServer::start().await;
+
+        let mut inputs = BlockInputs::new();
+        inputs.insert(
+            HandleName::from("message"),
+            Arc::new(OutputValue::new(serde_json::json!("hello"), true)),
+        );
+
+        Mock::given(method("POST"))
+            .and(path("/v1/actions/run-action"))
+            .and(header("authorization", "Bearer test-token"))
+            .and(body_json(serde_json::json!({
+                "input": {
+                    "message": "hello"
+                }
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "success": true,
+                "message": "ok",
+                "data": {
+                    "result": "ok"
+                },
+                "meta": {
+                    "executionId": "exec-1",
+                    "actionId": "run-action"
+                }
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let outputs = run_connector_action_with_configuration(
+            "run-action",
+            Some(inputs),
+            None,
+            Duration::from_secs(30),
+            Some(mock_server.uri().as_str()),
+            Some("test-token"),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            outputs.get(&HandleName::from("result")),
+            Some(&serde_json::json!("ok"))
         );
     }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -781,6 +781,7 @@ mod tests {
                 shared: Arc::new(shared::Shared {
                     session_id,
                     address: "127.0.0.1:0".to_string(),
+                    connector_base_url: None,
                     connector_auth_token: None,
                     scheduler_tx,
                     delay_abort_tx,
@@ -896,10 +897,10 @@ mod tests {
         let root = project_root();
         let runtime = TestRuntime::new(&root);
         let flow_path = root.join("tests/fixtures/connector-flow.oo.yaml");
-        let previous_connector_base_url = std::env::var_os("CONNECTOR_BASE_URL");
+        let previous_connector_base_url = std::env::var_os("OOCANA_CONNECTOR_BASE_URL");
 
         unsafe {
-            std::env::set_var("CONNECTOR_BASE_URL", mock_server.uri());
+            std::env::set_var("OOCANA_CONNECTOR_BASE_URL", mock_server.uri());
             std::env::set_var("OOMOL_TOKEN", "test-token");
         }
 
@@ -922,9 +923,9 @@ mod tests {
 
         unsafe {
             if let Some(value) = previous_connector_base_url {
-                std::env::set_var("CONNECTOR_BASE_URL", value);
+                std::env::set_var("OOCANA_CONNECTOR_BASE_URL", value);
             } else {
-                std::env::remove_var("CONNECTOR_BASE_URL");
+                std::env::remove_var("OOCANA_CONNECTOR_BASE_URL");
             }
             if let Some(value) = previous_oomol_token {
                 std::env::set_var("OOMOL_TOKEN", value);

--- a/runtime/src/remote_task_config.rs
+++ b/runtime/src/remote_task_config.rs
@@ -1,5 +1,27 @@
 use std::collections::HashMap;
 
+pub fn resolve_connector_base_url(
+    cli_url: Option<&str>,
+    env_file_vars: &HashMap<String, String>,
+) -> Option<String> {
+    cli_url
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_owned())
+        .or_else(|| {
+            std::env::var("OOCANA_CONNECTOR_BASE_URL")
+                .ok()
+                .map(|s| s.trim().to_owned())
+                .filter(|s| !s.is_empty())
+        })
+        .or_else(|| {
+            env_file_vars
+                .get("OOCANA_CONNECTOR_BASE_URL")
+                .map(|s| s.trim().to_owned())
+                .filter(|s| !s.is_empty())
+        })
+}
+
 pub fn resolve_auth_token(env_file_vars: &HashMap<String, String>) -> Option<String> {
     std::env::var("OOMOL_TOKEN")
         .ok()
@@ -11,6 +33,74 @@ pub fn resolve_auth_token(env_file_vars: &HashMap<String, String>) -> Option<Str
                 .map(|s| s.trim().to_owned())
                 .filter(|s| !s.is_empty())
         })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    #[test]
+    fn resolve_connector_base_url_prefers_cli_over_env_and_env_file() {
+        let env_guard = crate::CONNECTOR_ENV_LOCK
+            .get_or_init(|| std::sync::Mutex::new(()))
+            .lock()
+            .unwrap();
+        let previous = std::env::var_os("OOCANA_CONNECTOR_BASE_URL");
+        let mut env_file_vars = HashMap::new();
+        env_file_vars.insert(
+            "OOCANA_CONNECTOR_BASE_URL".to_string(),
+            "https://env-file.example".to_string(),
+        );
+
+        unsafe {
+            std::env::set_var("OOCANA_CONNECTOR_BASE_URL", "https://env.example");
+        }
+
+        let resolved = resolve_connector_base_url(Some("https://cli.example"), &env_file_vars);
+
+        unsafe {
+            if let Some(value) = previous {
+                std::env::set_var("OOCANA_CONNECTOR_BASE_URL", value);
+            } else {
+                std::env::remove_var("OOCANA_CONNECTOR_BASE_URL");
+            }
+        }
+        drop(env_guard);
+
+        assert_eq!(resolved.as_deref(), Some("https://cli.example"));
+    }
+
+    #[test]
+    fn resolve_connector_base_url_falls_back_to_env_file() {
+        let env_guard = crate::CONNECTOR_ENV_LOCK
+            .get_or_init(|| std::sync::Mutex::new(()))
+            .lock()
+            .unwrap();
+        let previous = std::env::var_os("OOCANA_CONNECTOR_BASE_URL");
+        let mut env_file_vars = HashMap::new();
+        env_file_vars.insert(
+            "OOCANA_CONNECTOR_BASE_URL".to_string(),
+            "https://env-file.example".to_string(),
+        );
+
+        unsafe {
+            std::env::remove_var("OOCANA_CONNECTOR_BASE_URL");
+        }
+
+        let resolved = resolve_connector_base_url(None, &env_file_vars);
+
+        unsafe {
+            if let Some(value) = previous {
+                std::env::set_var("OOCANA_CONNECTOR_BASE_URL", value);
+            } else {
+                std::env::remove_var("OOCANA_CONNECTOR_BASE_URL");
+            }
+        }
+        drop(env_guard);
+
+        assert_eq!(resolved.as_deref(), Some("https://env-file.example"));
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/runtime/src/shared.rs
+++ b/runtime/src/shared.rs
@@ -8,6 +8,7 @@ use crate::remote_task_config::RemoteTaskConfig;
 pub struct Shared {
     pub session_id: SessionId,
     pub address: String,
+    pub connector_base_url: Option<String>,
     pub connector_auth_token: Option<String>,
     pub scheduler_tx: SchedulerTx,
     pub delay_abort_tx: DelayAbortTx,


### PR DESCRIPTION
## Summary
- add --connector-base-url to the run CLI and document it as overriding OOCANA_CONNECTOR_BASE_URL
- resolve connector base URL with CLI > process env > env_file precedence and pass it through shared runtime state
- update connector execution to use the resolved base URL explicitly and add CLI/runtime tests for parsing and behavior

## Testing
- cargo test -p cli run_command_parses_connector_base_url
- cargo test -p runtime connector_executor
- cargo test -p runtime resolve_connector_base_url