### PR TITLE
refactor(layer)!: rename registry layer store to external layer store

### DIFF
--- a/cli/src/layer.rs
+++ b/cli/src/layer.rs
@@ -35,8 +35,8 @@ pub enum LayerAction {
         )]
         env_file: Option<String>,
     },
-    #[command(about = "create registry package layer")]
-    CreateRegistry {
+    #[command(about = "create external package layer")]
+    CreateExternal {
         #[arg(help = "package name")]
         package_name: String,
         #[arg(help = "package version")]
@@ -69,8 +69,8 @@ pub enum LayerAction {
         #[arg(help = "package path")]
         package: String,
     },
-    #[command(about = "delete registry package layer")]
-    DeleteRegistry {
+    #[command(about = "delete external package layer")]
+    DeleteExternal {
         #[arg(help = "package name")]
         package_name: String,
         #[arg(help = "package version")]
@@ -80,15 +80,15 @@ pub enum LayerAction {
     Get {
         #[arg(help = "package path")]
         package: String,
-        #[arg(help = "package name for registry layer (optional)", long)]
+        #[arg(help = "package name for external layer (optional)", long)]
         package_name: Option<String>,
-        #[arg(help = "package version for registry layer (optional)", long)]
+        #[arg(help = "package version for external layer (optional)", long)]
         version: Option<String>,
     },
     #[command(
-        about = "get registry package layer (deprecated: use 'get' with --package-name and --version)"
+        about = "get external package layer (deprecated: use 'get' with --package-name and --version)"
     )]
-    GetRegistry {
+    GetExternal {
         #[arg(help = "package name")]
         package_name: String,
         #[arg(help = "package version")]
@@ -130,11 +130,11 @@ pub enum LayerAction {
     DeleteAll {},
 }
 
-/// Get layer status with registry fallback logic (same as Get command).
+/// Get layer status with external fallback logic (same as Get command).
 /// If override_name and override_version are provided, they take precedence over package meta.
-/// Returns Exist if registry or package layer exists, NotInStore otherwise.
+/// Returns Exist if external or package layer exists, NotInStore otherwise.
 /// Errors are logged but treated as NotInStore.
-fn get_layer_status_with_registry_fallback(
+fn get_layer_status_with_external_fallback(
     package_path: &std::path::Path,
     override_name: Option<&str>,
     override_version: Option<&str>,
@@ -148,23 +148,23 @@ fn get_layer_status_with_registry_fallback(
             .unwrap_or((None, None)),
     };
 
-    // If we have both name and version, try registry layer first
+    // If we have both name and version, try external layer first
     if let (Some(ref name), Some(ref ver)) = (&pkg_name, &ver) {
-        match layer::registry_layer_status(name, ver) {
-            Ok(layer::RegistryLayerStatus::Exist) => {
+        match layer::external_layer_status(name, ver) {
+            Ok(layer::ExternalLayerStatus::Exist) => {
                 tracing::debug!(
-                    "find registry layer ({name}@{ver}) in {package_path:?} with status Exist"
+                    "find external layer ({name}@{ver}) in {package_path:?} with status Exist"
                 );
                 return layer::PackageLayerStatus::Exist;
             }
-            Ok(layer::RegistryLayerStatus::NotInStore) => {
+            Ok(layer::ExternalLayerStatus::NotInStore) => {
                 tracing::debug!(
-                    "registry layer ({name}@{ver}) not in store, fallback to package layer"
+                    "external layer ({name}@{ver}) not in store, fallback to package layer"
                 );
             }
             Err(e) => {
                 tracing::debug!(
-                    "get registry layer ({name}@{ver}) failed: {:?}, fallback to package layer",
+                    "get external layer ({name}@{ver}) failed: {:?}, fallback to package layer",
                     e
                 );
             }
@@ -229,7 +229,7 @@ pub fn layer_action(action: &LayerAction) -> Result<()> {
 
             layer::get_or_create_package_layer(package, &bind_path_arg, &envs, &env_file)?;
         }
-        LayerAction::CreateRegistry {
+        LayerAction::CreateExternal {
             package_name,
             version,
             package,
@@ -242,7 +242,7 @@ pub fn layer_action(action: &LayerAction) -> Result<()> {
                 .hide_source
             {
                 return Err(Error::from(format!(
-                    "Cannot create registry layer for package {package}: hide_source is enabled"
+                    "Cannot create external layer for package {package}: hide_source is enabled"
                 )));
             }
             let bind_path_arg = load_bind_paths(bind_paths, bind_path_file);
@@ -257,7 +257,7 @@ pub fn layer_action(action: &LayerAction) -> Result<()> {
 
             let env_file = find_env_file(env_file);
 
-            layer::create_registry_layer(
+            layer::create_external_layer(
                 package_name,
                 version,
                 package,
@@ -269,11 +269,11 @@ pub fn layer_action(action: &LayerAction) -> Result<()> {
         LayerAction::Delete { package } => {
             layer::delete_package_layer(package)?;
         }
-        LayerAction::DeleteRegistry {
+        LayerAction::DeleteExternal {
             package_name,
             version,
         } => {
-            layer::delete_registry_layer(package_name, version)?;
+            layer::delete_external_layer(package_name, version)?;
         }
         LayerAction::Get {
             package,
@@ -287,7 +287,7 @@ pub fn layer_action(action: &LayerAction) -> Result<()> {
                 println!("{:?}", layer::PackageLayerStatus::Exist);
                 return Ok(());
             }
-            let status = get_layer_status_with_registry_fallback(
+            let status = get_layer_status_with_external_fallback(
                 std::path::Path::new(package),
                 package_name.as_deref(),
                 version.as_deref(),
@@ -296,12 +296,12 @@ pub fn layer_action(action: &LayerAction) -> Result<()> {
             info!("package ({package}) status: {status:?}");
             println!("{status:?}");
         }
-        LayerAction::GetRegistry {
+        LayerAction::GetExternal {
             package_name,
             version,
         } => {
-            let status = layer::registry_layer_status(package_name, version)?;
-            info!("registry package ({package_name}@{version}) status: {status:?}");
+            let status = layer::external_layer_status(package_name, version)?;
+            info!("external package ({package_name}@{version}) status: {status:?}");
             println!("{status:?}");
         }
         LayerAction::Scan {
@@ -347,7 +347,7 @@ pub fn layer_action(action: &LayerAction) -> Result<()> {
                                         );
                                         continue;
                                     }
-                                    let status = get_layer_status_with_registry_fallback(
+                                    let status = get_layer_status_with_external_fallback(
                                         &scope_path,
                                         None,
                                         None,
@@ -370,7 +370,7 @@ pub fn layer_action(action: &LayerAction) -> Result<()> {
                                     continue;
                                 }
                                 let status =
-                                    get_layer_status_with_registry_fallback(&path, None, None);
+                                    get_layer_status_with_external_fallback(&path, None, None);
                                 package_map.insert(path, format!("{status:?}"));
                             }
                         }
@@ -444,15 +444,15 @@ pub fn layer_action(action: &LayerAction) -> Result<()> {
                 println!("{info}");
             }
 
-            match layer::load_registry_store() {
+            match layer::load_external_store() {
                 Ok(store) => {
                     for (key, l) in store.packages {
-                        let info = format!("Registry: {}, Path: {:?}", key, l.package_path);
+                        let info = format!("External: {}, Path: {:?}", key, l.package_path);
                         println!("{info}");
                     }
                 }
                 Err(e) => {
-                    tracing::warn!("load registry store failed: {e}");
+                    tracing::warn!("load external store failed: {e}");
                 }
             }
         }

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -198,16 +198,16 @@ pub fn cli_match() -> Result<()> {
                 LogParams {
                     sub_dir: Some("package-layer"),
                     log_name: "action",
-                    // create 和 create-registry 要将特定 stdout stderr 的 target 输出到控制台。因此两个都要为 true。
+                    // create 和 create-external 要将特定 stdout stderr 的 target 输出到控制台。因此两个都要为 true。
                     output_to_console: matches!(
                         action,
                         layer::LayerAction::Create { .. }
-                            | layer::LayerAction::CreateRegistry { .. }
+                            | layer::LayerAction::CreateExternal { .. }
                     ),
                     capture_stdout_stderr_target: matches!(
                         action,
                         layer::LayerAction::Create { .. }
-                            | layer::LayerAction::CreateRegistry { .. }
+                            | layer::LayerAction::CreateExternal { .. }
                     ),
                 }
             })?

--- a/cli/src/tests.rs
+++ b/cli/src/tests.rs
@@ -357,26 +357,26 @@ fn package_layer_subcommands_parse() {
         other => panic!("expected package-layer create command, got {other:?}"),
     }
 
-    let create_registry = parse_cli(&[
+    let create_external = parse_cli(&[
         "oocana",
         "package-layer",
-        "create-registry",
+        "create-external",
         "@pkg/name",
         "1.0.0",
         "/pkg/path",
         "--bind-paths",
         "src=/src,dst=/dst",
         "--bind-path-file",
-        "/tmp/registry-binds.txt",
+        "/tmp/external-binds.txt",
         "--retain-env-keys",
         "TOKEN",
         "--env-file",
-        ".env.registry",
+        ".env.external",
     ]);
-    match create_registry.command {
+    match create_external.command {
         Commands::PackageLayer {
             action:
-                layer::LayerAction::CreateRegistry {
+                layer::LayerAction::CreateExternal {
                     package_name,
                     version,
                     package,
@@ -390,11 +390,11 @@ fn package_layer_subcommands_parse() {
             assert_eq!(version, "1.0.0");
             assert_eq!(package, "/pkg/path");
             assert_eq!(bind_paths, Some(vec!["src=/src,dst=/dst".to_string()]));
-            assert_eq!(bind_path_file.as_deref(), Some("/tmp/registry-binds.txt"));
+            assert_eq!(bind_path_file.as_deref(), Some("/tmp/external-binds.txt"));
             assert_eq!(retain_env_keys, Some(vec!["TOKEN".to_string()]));
-            assert_eq!(env_file.as_deref(), Some(".env.registry"));
+            assert_eq!(env_file.as_deref(), Some(".env.external"));
         }
-        other => panic!("expected package-layer create-registry command, got {other:?}"),
+        other => panic!("expected package-layer create-external command, got {other:?}"),
     }
 
     let delete = parse_cli(&["oocana", "package-layer", "delete", "/pkg/path"]);
@@ -405,17 +405,17 @@ fn package_layer_subcommands_parse() {
         other => panic!("expected package-layer delete command, got {other:?}"),
     }
 
-    let delete_registry = parse_cli(&[
+    let delete_external = parse_cli(&[
         "oocana",
         "package-layer",
-        "delete-registry",
+        "delete-external",
         "@pkg/name",
         "1.0.0",
     ]);
-    match delete_registry.command {
+    match delete_external.command {
         Commands::PackageLayer {
             action:
-                layer::LayerAction::DeleteRegistry {
+                layer::LayerAction::DeleteExternal {
                     package_name,
                     version,
                 },
@@ -423,7 +423,7 @@ fn package_layer_subcommands_parse() {
             assert_eq!(package_name, "@pkg/name");
             assert_eq!(version, "1.0.0");
         }
-        other => panic!("expected package-layer delete-registry command, got {other:?}"),
+        other => panic!("expected package-layer delete-external command, got {other:?}"),
     }
 
     let get = parse_cli(&[
@@ -452,17 +452,17 @@ fn package_layer_subcommands_parse() {
         other => panic!("expected package-layer get command, got {other:?}"),
     }
 
-    let get_registry = parse_cli(&[
+    let get_external = parse_cli(&[
         "oocana",
         "package-layer",
-        "get-registry",
+        "get-external",
         "@pkg/name",
         "1.0.0",
     ]);
-    match get_registry.command {
+    match get_external.command {
         Commands::PackageLayer {
             action:
-                layer::LayerAction::GetRegistry {
+                layer::LayerAction::GetExternal {
                     package_name,
                     version,
                 },
@@ -470,7 +470,7 @@ fn package_layer_subcommands_parse() {
             assert_eq!(package_name, "@pkg/name");
             assert_eq!(version, "1.0.0");
         }
-        other => panic!("expected package-layer get-registry command, got {other:?}"),
+        other => panic!("expected package-layer get-external command, got {other:?}"),
     }
 
     let scan = parse_cli(&[

--- a/layer/src/external_layer_store.rs
+++ b/layer/src/external_layer_store.rs
@@ -1,4 +1,4 @@
-//! Registry layer store management.
+//! External layer store management.
 //!
 //! # Concurrency Model
 //!
@@ -7,21 +7,21 @@
 //!
 //! ## Write Operations (Single Writer Required)
 //!
-//! Functions that modify the registry store:
-//! - [`create_registry_layer`]
-//! - [`delete_registry_layer`]
-//! - [`save_registry_store`]
+//! Functions that modify the external store:
+//! - [`create_external_layer`]
+//! - [`delete_external_layer`]
+//! - [`save_external_store`]
 //!
 //! **Callers MUST ensure only ONE process executes write operations at any time.**
 //! No file locks are used. Concurrent writes will race (last write wins, data loss possible).
 //!
 //! ## Read Operations (Multi-Reader Safe)
 //!
-//! Functions that only read the registry store:
-//! - [`get_registry_layer`]
-//! - [`list_registry_layers`]
-//! - [`registry_layer_status`]
-//! - [`load_registry_store`]
+//! Functions that only read the external store:
+//! - [`get_external_layer`]
+//! - [`list_external_layers`]
+//! - [`external_layer_status`]
+//! - [`load_external_store`]
 //!
 //! Multiple processes can safely read concurrently, even while a single writer is active.
 //! Atomic rename ensures readers always see consistent data (never partial writes).
@@ -46,30 +46,61 @@ use std::env;
 use std::path::Path;
 use utils::{config, error::Result};
 
-/// Generate registry key from package_name and version.
+/// Generate external key from package_name and version.
 /// Format: `package_name@version`
-pub fn registry_key(package_name: &str, version: &str) -> String {
+pub fn external_key(package_name: &str, version: &str) -> String {
     format!("{package_name}@{version}")
 }
 
 const MAX_READ_RETRIES: usize = 5;
 const RETRY_DELAY_MS: u64 = 1000;
 
-/// Load registry store with retry mechanism for NFS compatibility.
+/// One-shot migration from the legacy `package_store.json` file name to
+/// `external_store.json` in the same directory. Safe to call on every load:
+/// only renames when the new file is absent and the legacy file exists.
+fn migrate_legacy_store_file(file_path: &Path) {
+    if file_path.exists() {
+        return;
+    }
+    let Some(parent) = file_path.parent() else {
+        return;
+    };
+    let legacy_path = parent.join("package_store.json");
+    if !legacy_path.exists() {
+        return;
+    }
+    match std::fs::rename(&legacy_path, file_path) {
+        Ok(_) => tracing::info!(
+            "Migrated legacy external store: {:?} -> {:?}",
+            legacy_path,
+            file_path
+        ),
+        Err(e) => tracing::warn!(
+            "Failed to migrate legacy external store {:?} -> {:?}: {:?}",
+            legacy_path,
+            file_path,
+            e
+        ),
+    }
+}
+
+/// Load external store with retry mechanism for NFS compatibility.
 /// Retries on read/parse failures to handle transient issues during atomic writes.
-fn load_registry_store_with_retry() -> Result<RegistryLayerStore> {
+fn load_external_store_with_retry() -> Result<ExternalLayerStore> {
     let file_path =
-        config::registry_store_file().ok_or("Failed to get registry store file path")?;
+        config::external_store_file().ok_or("Failed to get external store file path")?;
+
+    migrate_legacy_store_file(&file_path);
 
     for attempt in 0..MAX_READ_RETRIES {
         match std::fs::read_to_string(&file_path) {
             Ok(content) => {
-                match serde_json::from_str::<RegistryLayerStore>(&content) {
+                match serde_json::from_str::<ExternalLayerStore>(&content) {
                     Ok(store) => {
                         // Version check (preserve existing logic)
                         if store.version != env!("CARGO_PKG_VERSION") {
                             tracing::warn!(
-                                "Registry store version mismatch: {} != {}, proceeding without migration",
+                                "External store version mismatch: {} != {}, proceeding without migration",
                                 store.version,
                                 env!("CARGO_PKG_VERSION")
                             );
@@ -90,7 +121,7 @@ fn load_registry_store_with_retry() -> Result<RegistryLayerStore> {
             }
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
                 // File doesn't exist, initialize new store
-                return Ok(RegistryLayerStore {
+                return Ok(ExternalLayerStore {
                     version: env!("CARGO_PKG_VERSION").to_string(),
                     packages: HashMap::new(),
                 });
@@ -111,11 +142,11 @@ fn load_registry_store_with_retry() -> Result<RegistryLayerStore> {
     unreachable!()
 }
 
-/// Atomically save registry store using write-to-temp + rename.
+/// Atomically save external store using write-to-temp + rename.
 /// This is NFS-safe and more reliable than file locks.
-fn save_registry_store_atomic(store: &RegistryLayerStore) -> Result<()> {
+fn save_external_store_atomic(store: &ExternalLayerStore) -> Result<()> {
     let file_path =
-        config::registry_store_file().ok_or("Failed to get registry store file path")?;
+        config::external_store_file().ok_or("Failed to get external store file path")?;
 
     // Ensure directory exists
     if let Some(dir) = file_path.parent() {
@@ -137,14 +168,14 @@ fn save_registry_store_atomic(store: &RegistryLayerStore) -> Result<()> {
 }
 
 #[derive(Debug, PartialEq, Eq)]
-pub enum RegistryLayerStatus {
+pub enum ExternalLayerStatus {
     NotInStore,
     Exist,
 }
 
-pub fn registry_layer_status(package_name: &str, version: &str) -> Result<RegistryLayerStatus> {
-    let key = registry_key(package_name, version);
-    let store = load_registry_store()?;
+pub fn external_layer_status(package_name: &str, version: &str) -> Result<ExternalLayerStatus> {
+    let key = external_key(package_name, version);
+    let store = load_external_store()?;
 
     let package = store.packages.get(&key);
 
@@ -157,26 +188,26 @@ pub fn registry_layer_status(package_name: &str, version: &str) -> Result<Regist
                     version,
                     p.version
                 );
-                Ok(RegistryLayerStatus::NotInStore)
+                Ok(ExternalLayerStatus::NotInStore)
             } else {
                 match p.validate() {
-                    Ok(_) => Ok(RegistryLayerStatus::Exist),
+                    Ok(_) => Ok(ExternalLayerStatus::Exist),
                     Err(e) => {
                         tracing::debug!("{} layer validation failed: {}", key, e);
-                        Ok(RegistryLayerStatus::NotInStore)
+                        Ok(ExternalLayerStatus::NotInStore)
                     }
                 }
             }
         }
-        None => Ok(RegistryLayerStatus::NotInStore),
+        None => Ok(ExternalLayerStatus::NotInStore),
     }
 }
 
-/// Create or update a registry layer.
+/// Create or update an external layer.
 ///
 /// # Concurrency Requirements
 ///
-/// **IMPORTANT: This is a WRITE operation. Only ONE process can call registry write functions
+/// **IMPORTANT: This is a WRITE operation. Only ONE process can call external write functions
 /// at the same time.**
 ///
 /// See module-level documentation for detailed concurrency requirements.
@@ -185,16 +216,16 @@ pub fn registry_layer_status(package_name: &str, version: &str) -> Result<Regist
 ///
 /// - If the layer exists and is valid, returns it
 /// - If the layer is invalid or doesn't exist, creates a new one
-/// - Always writes to the registry store (potential data race if called concurrently)
+/// - Always writes to the external store (potential data race if called concurrently)
 ///
 /// # Intended Usage
 ///
 /// This function should ONLY be called from:
-/// - CLI `create-registry` command
+/// - CLI `create-external` command
 /// - Explicit package installation workflows
 ///
-/// Runtime code should use [`get_registry_layer`] instead.
-pub fn create_registry_layer<P: AsRef<Path>>(
+/// Runtime code should use [`get_external_layer`] instead.
+pub fn create_external_layer<P: AsRef<Path>>(
     package_name: &str,
     version: &str,
     package_path: P,
@@ -202,7 +233,7 @@ pub fn create_registry_layer<P: AsRef<Path>>(
     envs: &HashMap<String, String>,
     env_file: &Option<String>,
 ) -> Result<PackageLayer> {
-    let key = registry_key(package_name, version);
+    let key = external_key(package_name, version);
     let package_path = package_path.as_ref();
 
     // Get package metadata to extract bootstrap
@@ -212,7 +243,7 @@ pub fn create_registry_layer<P: AsRef<Path>>(
         .and_then(|scripts| scripts.bootstrap);
 
     // Load the store with retry mechanism
-    let mut store = load_registry_store()?;
+    let mut store = load_external_store()?;
 
     // Check if existing package is valid
     if let Some(p) = store.packages.get(&key) {
@@ -238,42 +269,42 @@ pub fn create_registry_layer<P: AsRef<Path>>(
 
     // Insert and save atomically
     store.packages.insert(key, layer.clone());
-    save_registry_store_atomic(&store)?;
+    save_external_store_atomic(&store)?;
 
     Ok(layer)
 }
 
-pub(crate) fn add_import_registry_package(pkg: &PackageLayer) -> Result<()> {
+pub(crate) fn add_import_external_package(pkg: &PackageLayer) -> Result<()> {
     let package_name = pkg
         .name
         .as_deref()
-        .ok_or("Failed to import registry package: missing package name")?;
+        .ok_or("Failed to import external package: missing package name")?;
     let version = pkg
         .version
         .as_deref()
-        .ok_or("Failed to import registry package: missing package version")?;
+        .ok_or("Failed to import external package: missing package version")?;
 
-    let key = registry_key(package_name, version);
-    let mut store = load_registry_store()?;
+    let key = external_key(package_name, version);
+    let mut store = load_external_store()?;
     store.packages.insert(key, pkg.clone());
-    save_registry_store_atomic(&store)?;
+    save_external_store_atomic(&store)?;
     Ok(())
 }
 
-pub(crate) fn remove_import_registry_package(
+pub(crate) fn remove_import_external_package(
     package_name: &str,
     version: &str,
 ) -> Result<Option<PackageLayer>> {
-    let key = registry_key(package_name, version);
-    let mut store = load_registry_store()?;
+    let key = external_key(package_name, version);
+    let mut store = load_external_store()?;
     let removed = store.packages.remove(&key);
-    save_registry_store_atomic(&store)?;
+    save_external_store_atomic(&store)?;
     Ok(removed)
 }
 
-pub fn get_registry_layer(package_name: &str, version: &str) -> Result<Option<PackageLayer>> {
-    let key = registry_key(package_name, version);
-    let store = load_registry_store()?;
+pub fn get_external_layer(package_name: &str, version: &str) -> Result<Option<PackageLayer>> {
+    let key = external_key(package_name, version);
+    let store = load_external_store()?;
 
     match store.packages.get(&key) {
         Some(p) if p.validate().is_ok() => Ok(Some(p.clone())),
@@ -281,25 +312,25 @@ pub fn get_registry_layer(package_name: &str, version: &str) -> Result<Option<Pa
     }
 }
 
-/// Delete a registry layer and its associated OCI layers.
+/// Delete an external layer and its associated OCI layers.
 ///
 /// # Concurrency Requirements
 ///
-/// **IMPORTANT: This is a WRITE operation. Only ONE process can call registry write functions
+/// **IMPORTANT: This is a WRITE operation. Only ONE process can call external write functions
 /// at the same time.**
 ///
 /// See module-level documentation for detailed concurrency requirements.
 ///
 /// # Behavior
 ///
-/// - Removes the package entry from the registry store
+/// - Removes the package entry from the external store
 /// - Deletes associated OCI layers if they are not shared or in use
 /// - Skips deletion of layers that are:
-///   - Referenced by other packages in the registry
+///   - Referenced by other packages in the external store
 ///   - Currently in use by running containers
-pub fn delete_registry_layer(package_name: &str, version: &str) -> Result<()> {
-    let key = registry_key(package_name, version);
-    let mut store = load_registry_store()?;
+pub fn delete_external_layer(package_name: &str, version: &str) -> Result<()> {
+    let key = external_key(package_name, version);
+    let mut store = load_external_store()?;
 
     // Remove the package and collect all its layers
     let pkg_layer = store.packages.remove(&key);
@@ -342,7 +373,7 @@ pub fn delete_registry_layer(package_name: &str, version: &str) -> Result<()> {
     }
 
     // Save the modified store regardless of delete errors
-    save_registry_store(&store)?;
+    save_external_store(&store)?;
 
     // Return error if any deletions failed
     if !delete_errors.is_empty() {
@@ -352,20 +383,20 @@ pub fn delete_registry_layer(package_name: &str, version: &str) -> Result<()> {
     Ok(())
 }
 
-pub fn list_registry_layers() -> Result<Vec<PackageLayer>> {
-    let store = load_registry_store()?;
+pub fn list_external_layers() -> Result<Vec<PackageLayer>> {
+    let store = load_external_store()?;
     Ok(store.packages.into_values().collect())
 }
 
-pub fn load_registry_store() -> Result<RegistryLayerStore> {
-    load_registry_store_with_retry()
+pub fn load_external_store() -> Result<ExternalLayerStore> {
+    load_external_store_with_retry()
 }
 
-/// Save registry store to disk using atomic write.
+/// Save external store to disk using atomic write.
 ///
 /// # Concurrency Requirements
 ///
-/// **IMPORTANT: This is a WRITE operation. Only ONE process can call registry write functions
+/// **IMPORTANT: This is a WRITE operation. Only ONE process can call external write functions
 /// at the same time.**
 ///
 /// See module-level documentation for detailed concurrency requirements.
@@ -376,12 +407,12 @@ pub fn load_registry_store() -> Result<RegistryLayerStore> {
 /// - NFS compatibility (no reliance on file locks)
 /// - Readers never see partial/corrupted data
 /// - Write operation is all-or-nothing
-pub fn save_registry_store(store: &RegistryLayerStore) -> Result<()> {
-    save_registry_store_atomic(store)
+pub fn save_external_store(store: &ExternalLayerStore) -> Result<()> {
+    save_external_store_atomic(store)
 }
 
 #[derive(Serialize, Deserialize, Debug)]
-pub struct RegistryLayerStore {
+pub struct ExternalLayerStore {
     pub version: String,
     /// key format: package_name@version. package_name can be @scope/name or name
     pub packages: HashMap<String, PackageLayer>,
@@ -393,20 +424,20 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_registry_key() {
-        assert_eq!(registry_key("my-package", "1.0.0"), "my-package@1.0.0");
+    fn test_external_key() {
+        assert_eq!(external_key("my-package", "1.0.0"), "my-package@1.0.0");
         assert_eq!(
-            registry_key("@scope/my-package", "2.0.0"),
+            external_key("@scope/my-package", "2.0.0"),
             "@scope/my-package@2.0.0"
         );
     }
 
     #[test]
-    fn test_load_registry_store() {
-        let r = load_registry_store();
+    fn test_load_external_store() {
+        let r = load_external_store();
         assert!(
             r.is_ok(),
-            "load_registry_store failed: {:?}",
+            "load_external_store failed: {:?}",
             r.unwrap_err()
         );
     }

--- a/layer/src/lib.rs
+++ b/layer/src/lib.rs
@@ -1,4 +1,5 @@
 mod cli;
+mod external_layer_store;
 mod injection_layer;
 mod injection_store;
 mod layer;
@@ -6,20 +7,19 @@ mod layer_settings;
 mod ovmlayer;
 mod package_layer;
 mod package_store;
-mod registry_layer_store;
 mod runtime_layer;
 
 use std::process::Command;
 
+pub use external_layer_store::{
+    ExternalLayerStatus, ExternalLayerStore, create_external_layer, delete_external_layer,
+    external_layer_status, get_external_layer, list_external_layers, load_external_store,
+};
 pub use ovmlayer::BindPath;
 pub use package_layer::{import_package_layer, move_package_layer};
 pub use package_store::{
     PackageLayerStatus, delete_all_layer_data, delete_package_layer, get_or_create_package_layer,
     list_package_layers, package_layer_status,
-};
-pub use registry_layer_store::{
-    RegistryLayerStatus, RegistryLayerStore, create_registry_layer, delete_registry_layer,
-    get_registry_layer, list_registry_layers, load_registry_store, registry_layer_status,
 };
 pub use runtime_layer::{InjectionParams, RuntimeLayer, create_runtime_layer};
 

--- a/layer/src/package_layer.rs
+++ b/layer/src/package_layer.rs
@@ -257,7 +257,7 @@ fi
     Ok(())
 }
 
-fn migrate_package_store_to_registry(package: &PackageLayer) -> Result<()> {
+fn migrate_package_store_to_external(package: &PackageLayer) -> Result<()> {
     let package_name = package
         .name
         .as_deref()
@@ -266,26 +266,26 @@ fn migrate_package_store_to_registry(package: &PackageLayer) -> Result<()> {
         .version
         .as_deref()
         .ok_or("Failed to move package layer: missing package version")?;
-    let key = crate::registry_layer_store::registry_key(package_name, version);
-    let registry = crate::registry_layer_store::load_registry_store()?;
-    let previous_registry_package = registry.packages.get(&key).cloned();
+    let key = crate::external_layer_store::external_key(package_name, version);
+    let external = crate::external_layer_store::load_external_store()?;
+    let previous_external_package = external.packages.get(&key).cloned();
 
-    if previous_registry_package.is_some() {
+    if previous_external_package.is_some() {
         tracing::warn!(
             package_name,
             version,
-            "package already exists in registry store and will overwrite old layers"
+            "package already exists in external store and will overwrite old layers"
         );
     }
 
-    crate::registry_layer_store::add_import_registry_package(package)?;
+    crate::external_layer_store::add_import_external_package(package)?;
 
     if let Err(err) = remove_package_from_store(&package.package_path) {
         let rollback_result =
-            if let Some(previous_registry_package) = previous_registry_package.as_ref() {
-                crate::registry_layer_store::add_import_registry_package(previous_registry_package)
+            if let Some(previous_external_package) = previous_external_package.as_ref() {
+                crate::external_layer_store::add_import_external_package(previous_external_package)
             } else {
-                crate::registry_layer_store::remove_import_registry_package(package_name, version)
+                crate::external_layer_store::remove_import_external_package(package_name, version)
                     .map(|_| ())
             };
 
@@ -295,7 +295,7 @@ fn migrate_package_store_to_registry(package: &PackageLayer) -> Result<()> {
                 package_name,
                 version,
                 error = %rollback_err,
-                "failed to rollback registry entry after package store removal error"
+                "failed to rollback external entry after package store removal error"
             );
             return Err(format!(
                 "failed to remove package from store for {package_name}@{version}: {err}; rollback also failed: {rollback_err}"
@@ -305,8 +305,8 @@ fn migrate_package_store_to_registry(package: &PackageLayer) -> Result<()> {
         return Err(err);
     }
 
-    if let Some(previous_registry_package) = previous_registry_package.as_ref() {
-        delete_overwritten_layers(previous_registry_package, package);
+    if let Some(previous_external_package) = previous_external_package.as_ref() {
+        delete_overwritten_layers(previous_external_package, package);
     }
 
     Ok(())
@@ -330,14 +330,14 @@ fn delete_overwritten_layers(old_package: &PackageLayer, new_package: &PackageLa
                 old_package_path = %old_package.package_path.display(),
                 new_package_path = %new_package.package_path.display(),
                 error = %err,
-                "failed to delete overwritten layer after registry migration"
+                "failed to delete overwritten layer after external migration"
             );
         }
     }
 }
 
 /// Moves all layers of a package from the package store to the ovmlayer external store,
-/// then migrates the package metadata to the registry store.
+/// then migrates the package metadata to the external store.
 ///
 /// This operation is not atomic. If one or more layer moves fail, previously moved
 /// layers remain in the external store while the package metadata stays in the package
@@ -387,7 +387,7 @@ pub fn move_package_layer(package_path: &str) -> Result<()> {
         .into());
     }
 
-    migrate_package_store_to_registry(&package)
+    migrate_package_store_to_external(&package)
 }
 
 fn diff(a: HashSet<String>, b: HashSet<String>) -> Vec<String> {
@@ -404,7 +404,7 @@ mod tests {
 
     struct TestStoreGuard {
         original_store_dir: String,
-        original_registry_store_file: String,
+        original_external_store_file: String,
         _serial: std::sync::MutexGuard<'static, ()>,
     }
 
@@ -413,19 +413,19 @@ mod tests {
             let serial = TEST_CONFIG_LOCK.lock().unwrap();
             let mut config = GLOBAL_CONFIG.lock().unwrap();
             let original_store_dir = config.global.store_dir.clone();
-            let original_registry_store_file = config.global.registry_store_file.clone();
+            let original_external_store_file = config.global.external_store_file.clone();
 
             config.global.store_dir = base_dir.join("store").to_string_lossy().into_owned();
-            config.global.registry_store_file = base_dir
-                .join("registry")
-                .join("package_store.json")
+            config.global.external_store_file = base_dir
+                .join("external")
+                .join("external_store.json")
                 .to_string_lossy()
                 .into_owned();
             drop(config);
 
             Self {
                 original_store_dir,
-                original_registry_store_file,
+                original_external_store_file,
                 _serial: serial,
             }
         }
@@ -435,7 +435,7 @@ mod tests {
         fn drop(&mut self) {
             if let Ok(mut config) = GLOBAL_CONFIG.lock() {
                 config.global.store_dir = self.original_store_dir.clone();
-                config.global.registry_store_file = self.original_registry_store_file.clone();
+                config.global.external_store_file = self.original_external_store_file.clone();
             }
         }
     }
@@ -553,17 +553,17 @@ mod tests {
 
     #[cfg(target_os = "linux")]
     #[test]
-    fn test_migrate_package_store_to_registry_updates_both_stores() {
+    fn test_migrate_package_store_to_external_updates_both_stores() {
         use std::{fs, path::PathBuf};
 
         use super::*;
 
         let temp_root =
-            std::env::temp_dir().join(crate::layer::random_name("package_layer_registry_test"));
+            std::env::temp_dir().join(crate::layer::random_name("package_layer_external_test"));
         let _guard = TestStoreGuard::new(&temp_root);
-        let package_name = "@oomol/import-registry-test";
+        let package_name = "@oomol/import-external-test";
         let package_version = "0.1.3";
-        let package_path = PathBuf::from("/tmp/import-registry-test");
+        let package_path = PathBuf::from("/tmp/import-external-test");
         let package = PackageLayer {
             name: Some(package_name.to_string()),
             version: Some(package_version.to_string()),
@@ -576,7 +576,7 @@ mod tests {
 
         add_import_package(&package).unwrap();
 
-        migrate_package_store_to_registry(&package).unwrap();
+        migrate_package_store_to_external(&package).unwrap();
 
         let package_store = crate::package_store::load_package_store().unwrap();
         assert!(
@@ -585,12 +585,12 @@ mod tests {
                 .contains_key(&package_path.to_string_lossy().to_string())
         );
 
-        let registry_store = crate::registry_layer_store::load_registry_store().unwrap();
-        let key = crate::registry_layer_store::registry_key(package_name, package_version);
-        let migrated = registry_store
+        let external_store = crate::external_layer_store::load_external_store().unwrap();
+        let key = crate::external_layer_store::external_key(package_name, package_version);
+        let migrated = external_store
             .packages
             .get(&key)
-            .expect("registry package should exist after migration");
+            .expect("external package should exist after migration");
         assert_eq!(migrated.name.as_deref(), Some(package_name));
         assert_eq!(migrated.version.as_deref(), Some(package_version));
 
@@ -599,18 +599,18 @@ mod tests {
 
     #[cfg(target_os = "linux")]
     #[test]
-    fn test_migrate_package_store_to_registry_overwrites_existing_registry_entry_and_deletes_old_layers()
+    fn test_migrate_package_store_to_external_overwrites_existing_external_entry_and_deletes_old_layers()
      {
         use std::{fs, path::PathBuf};
 
         use super::*;
 
         let temp_root =
-            std::env::temp_dir().join(crate::layer::random_name("package_layer_registry_conflict"));
+            std::env::temp_dir().join(crate::layer::random_name("package_layer_external_conflict"));
         let _guard = TestStoreGuard::new(&temp_root);
-        let package_name = "@oomol/import-registry-conflict";
+        let package_name = "@oomol/import-external-conflict";
         let package_version = "0.1.4";
-        let package_path = PathBuf::from("/tmp/import-registry-conflict");
+        let package_path = PathBuf::from("/tmp/import-external-conflict");
         let old_base_layer = create_random_layer().unwrap();
         let old_source_layer = create_random_layer().unwrap();
         let old_bootstrap_layer = create_random_layer().unwrap();
@@ -626,21 +626,21 @@ mod tests {
             bootstrap_layer: Some(new_bootstrap_layer.clone()),
             package_path: package_path.clone(),
         };
-        let existing_registry_package = PackageLayer {
+        let existing_external_package = PackageLayer {
             name: Some(package_name.to_string()),
             version: Some(package_version.to_string()),
             base_layers: Some(vec![old_base_layer.clone()]),
             source_layer: old_source_layer.clone(),
             bootstrap: None,
             bootstrap_layer: Some(old_bootstrap_layer.clone()),
-            package_path: PathBuf::from("/tmp/old-import-registry-conflict"),
+            package_path: PathBuf::from("/tmp/old-import-external-conflict"),
         };
 
         add_import_package(&package).unwrap();
-        crate::registry_layer_store::add_import_registry_package(&existing_registry_package)
+        crate::external_layer_store::add_import_external_package(&existing_external_package)
             .unwrap();
 
-        migrate_package_store_to_registry(&package).unwrap();
+        migrate_package_store_to_external(&package).unwrap();
 
         let package_store = crate::package_store::load_package_store().unwrap();
         assert!(
@@ -649,12 +649,12 @@ mod tests {
                 .contains_key(&package_path.to_string_lossy().to_string())
         );
 
-        let registry_store = crate::registry_layer_store::load_registry_store().unwrap();
-        let key = crate::registry_layer_store::registry_key(package_name, package_version);
-        let migrated = registry_store
+        let external_store = crate::external_layer_store::load_external_store().unwrap();
+        let key = crate::external_layer_store::external_key(package_name, package_version);
+        let migrated = external_store
             .packages
             .get(&key)
-            .expect("registry package should exist after overwrite");
+            .expect("external package should exist after overwrite");
         assert_eq!(migrated.source_layer, new_source_layer);
         assert_eq!(migrated.base_layers, Some(vec![new_base_layer.clone()]));
         assert_eq!(migrated.bootstrap_layer, Some(new_bootstrap_layer.clone()));
@@ -681,17 +681,17 @@ mod tests {
 
     #[cfg(target_os = "linux")]
     #[test]
-    fn test_migrate_package_store_to_registry_rolls_back_registry_on_package_store_failure() {
+    fn test_migrate_package_store_to_external_rolls_back_external_on_package_store_failure() {
         use std::{fs, path::PathBuf};
 
         use super::*;
 
         let temp_root =
-            std::env::temp_dir().join(crate::layer::random_name("package_layer_registry_rollback"));
+            std::env::temp_dir().join(crate::layer::random_name("package_layer_external_rollback"));
         let _guard = TestStoreGuard::new(&temp_root);
-        let package_name = "@oomol/import-registry-rollback";
+        let package_name = "@oomol/import-external-rollback";
         let package_version = "0.1.5";
-        let package_path = PathBuf::from("/tmp/import-registry-rollback");
+        let package_path = PathBuf::from("/tmp/import-external-rollback");
         let package = PackageLayer {
             name: Some(package_name.to_string()),
             version: Some(package_version.to_string()),
@@ -715,7 +715,7 @@ mod tests {
                 .into_owned();
         }
 
-        let err = migrate_package_store_to_registry(&package).unwrap_err();
+        let err = migrate_package_store_to_external(&package).unwrap_err();
         assert!(
             err.to_string().contains("Failed to create dir"),
             "unexpected error: {err:?}"
@@ -726,11 +726,11 @@ mod tests {
             config.global.store_dir = temp_root.join("store").to_string_lossy().into_owned();
         }
 
-        let registry_store = crate::registry_layer_store::load_registry_store().unwrap();
-        let key = crate::registry_layer_store::registry_key(package_name, package_version);
+        let external_store = crate::external_layer_store::load_external_store().unwrap();
+        let key = crate::external_layer_store::external_key(package_name, package_version);
         assert!(
-            !registry_store.packages.contains_key(&key),
-            "registry entry should be rolled back"
+            !external_store.packages.contains_key(&key),
+            "external entry should be rolled back"
         );
 
         let package_store = crate::package_store::load_package_store().unwrap();
@@ -746,17 +746,17 @@ mod tests {
 
     #[cfg(target_os = "linux")]
     #[test]
-    fn test_migrate_package_store_to_registry_restores_previous_registry_entry_on_rollback() {
+    fn test_migrate_package_store_to_external_restores_previous_external_entry_on_rollback() {
         use std::{fs, path::PathBuf};
 
         use super::*;
 
         let temp_root =
-            std::env::temp_dir().join(crate::layer::random_name("package_layer_registry_restore"));
+            std::env::temp_dir().join(crate::layer::random_name("package_layer_external_restore"));
         let _guard = TestStoreGuard::new(&temp_root);
-        let package_name = "@oomol/import-registry-restore";
+        let package_name = "@oomol/import-external-restore";
         let package_version = "0.1.6";
-        let package_path = PathBuf::from("/tmp/import-registry-restore");
+        let package_path = PathBuf::from("/tmp/import-external-restore");
         let package = PackageLayer {
             name: Some(package_name.to_string()),
             version: Some(package_version.to_string()),
@@ -766,18 +766,18 @@ mod tests {
             bootstrap_layer: Some("new_layer_bootstrap".to_string()),
             package_path: package_path.clone(),
         };
-        let existing_registry_package = PackageLayer {
+        let existing_external_package = PackageLayer {
             name: Some(package_name.to_string()),
             version: Some(package_version.to_string()),
             base_layers: Some(vec!["old_layer_base".to_string()]),
             source_layer: "old_layer_source".to_string(),
             bootstrap: None,
             bootstrap_layer: Some("old_layer_bootstrap".to_string()),
-            package_path: PathBuf::from("/tmp/old-import-registry-restore"),
+            package_path: PathBuf::from("/tmp/old-import-external-restore"),
         };
 
         add_import_package(&package).unwrap();
-        crate::registry_layer_store::add_import_registry_package(&existing_registry_package)
+        crate::external_layer_store::add_import_external_package(&existing_external_package)
             .unwrap();
 
         let invalid_store_parent = temp_root.join("store-dir-blocker");
@@ -791,7 +791,7 @@ mod tests {
                 .into_owned();
         }
 
-        let err = migrate_package_store_to_registry(&package).unwrap_err();
+        let err = migrate_package_store_to_external(&package).unwrap_err();
         assert!(
             err.to_string().contains("Failed to create dir"),
             "unexpected error: {err:?}"
@@ -802,20 +802,20 @@ mod tests {
             config.global.store_dir = temp_root.join("store").to_string_lossy().into_owned();
         }
 
-        let registry_store = crate::registry_layer_store::load_registry_store().unwrap();
-        let key = crate::registry_layer_store::registry_key(package_name, package_version);
-        let restored = registry_store
+        let external_store = crate::external_layer_store::load_external_store().unwrap();
+        let key = crate::external_layer_store::external_key(package_name, package_version);
+        let restored = external_store
             .packages
             .get(&key)
-            .expect("previous registry entry should be restored after rollback");
+            .expect("previous external entry should be restored after rollback");
         assert_eq!(
             restored.source_layer,
-            existing_registry_package.source_layer
+            existing_external_package.source_layer
         );
-        assert_eq!(restored.base_layers, existing_registry_package.base_layers);
+        assert_eq!(restored.base_layers, existing_external_package.base_layers);
         assert_eq!(
             restored.bootstrap_layer,
-            existing_registry_package.bootstrap_layer
+            existing_external_package.bootstrap_layer
         );
 
         let package_store = crate::package_store::load_package_store().unwrap();
@@ -870,14 +870,14 @@ mod tests {
         move_package_layer(package.package_path.to_str().unwrap())
             .expect("move package layer failed");
 
-        let registry_package =
-            crate::registry_layer_store::get_registry_layer(package_name, package_version)
+        let external_package =
+            crate::external_layer_store::get_external_layer(package_name, package_version)
                 .unwrap()
-                .expect("registry package should exist after move");
-        assert_eq!(registry_package.package_path, package.package_path);
-        assert_eq!(registry_package.base_layers, Some(vec![base_layer]));
-        assert_eq!(registry_package.source_layer, package.source_layer);
-        assert_eq!(registry_package.bootstrap_layer, package.bootstrap_layer);
+                .expect("external package should exist after move");
+        assert_eq!(external_package.package_path, package.package_path);
+        assert_eq!(external_package.base_layers, Some(vec![base_layer]));
+        assert_eq!(external_package.source_layer, package.source_layer);
+        assert_eq!(external_package.bootstrap_layer, package.bootstrap_layer);
 
         let package_status =
             crate::package_store::package_layer_status(&package.package_path).unwrap();

--- a/layer/src/runtime_layer.rs
+++ b/layer/src/runtime_layer.rs
@@ -6,7 +6,7 @@ use crate::layer::{
 use crate::ovmlayer::{self, BindPath};
 use crate::package_layer::{CACHE_DIR, PackageLayer};
 use crate::package_store::get_or_create_package_layer;
-use crate::registry_layer_store::get_registry_layer;
+use crate::external_layer_store::get_external_layer;
 use std::collections::HashMap;
 use std::env::temp_dir;
 use std::fmt::Debug;
@@ -53,24 +53,24 @@ pub fn create_runtime_layer(
 
     let layer: std::result::Result<PackageLayer, utils::error::Error> =
         match (package_name, version) {
-            (Some(pkg_name), Some(ver)) => match get_registry_layer(pkg_name, ver) {
+            (Some(pkg_name), Some(ver)) => match get_external_layer(pkg_name, ver) {
                 Ok(Some(layer)) => {
                     info!(
-                        "get package layer from registry store: {}@{}",
+                        "get package layer from external store: {}@{}",
                         pkg_name, ver
                     );
                     Ok(layer)
                 }
                 Ok(None) => {
                     info!(
-                        "registry layer {}@{} not found, fallback to package layer",
+                        "external layer {}@{} not found, fallback to package layer",
                         pkg_name, ver
                     );
                     get_package_layer()
                 }
                 Err(e) => {
                     info!(
-                        "get registry layer failed: {:?}, fallback to package layer",
+                        "get external layer failed: {:?}, fallback to package layer",
                         e
                     );
                     get_package_layer()

--- a/layer/src/runtime_layer.rs
+++ b/layer/src/runtime_layer.rs
@@ -1,3 +1,4 @@
+use crate::external_layer_store::get_external_layer;
 use crate::injection_layer::InjectionLayer;
 use crate::injection_store::get_injection_layer;
 use crate::layer::{
@@ -6,7 +7,6 @@ use crate::layer::{
 use crate::ovmlayer::{self, BindPath};
 use crate::package_layer::{CACHE_DIR, PackageLayer};
 use crate::package_store::get_or_create_package_layer;
-use crate::external_layer_store::get_external_layer;
 use std::collections::HashMap;
 use std::env::temp_dir;
 use std::fmt::Debug;

--- a/layer/tests/package.rs
+++ b/layer/tests/package.rs
@@ -13,7 +13,7 @@ mod tests {
 
     struct TestStoreGuard {
         original_store_dir: String,
-        original_registry_store_file: String,
+        original_external_store_file: String,
         _serial: std::sync::MutexGuard<'static, ()>,
     }
 
@@ -22,19 +22,19 @@ mod tests {
             let serial = TEST_CONFIG_LOCK.lock().unwrap();
             let mut config = GLOBAL_CONFIG.lock().unwrap();
             let original_store_dir = config.global.store_dir.clone();
-            let original_registry_store_file = config.global.registry_store_file.clone();
+            let original_external_store_file = config.global.external_store_file.clone();
 
             config.global.store_dir = base_dir.join("store").to_string_lossy().into_owned();
-            config.global.registry_store_file = base_dir
-                .join("registry")
-                .join("package_store.json")
+            config.global.external_store_file = base_dir
+                .join("external")
+                .join("external_store.json")
                 .to_string_lossy()
                 .into_owned();
             drop(config);
 
             Self {
                 original_store_dir,
-                original_registry_store_file,
+                original_external_store_file,
                 _serial: serial,
             }
         }
@@ -44,7 +44,7 @@ mod tests {
         fn drop(&mut self) {
             if let Ok(mut config) = GLOBAL_CONFIG.lock() {
                 config.global.store_dir = self.original_store_dir.clone();
-                config.global.registry_store_file = self.original_registry_store_file.clone();
+                config.global.external_store_file = self.original_external_store_file.clone();
             }
         }
     }
@@ -203,11 +203,11 @@ scripts:
             PackageLayerStatus::NotInStore
         );
 
-        let registry_package = get_registry_layer("@oomol/move-real-test", "0.3.0")
+        let external_package = get_external_layer("@oomol/move-real-test", "0.3.0")
             .unwrap()
-            .expect("registry package should exist after move");
-        assert_eq!(registry_package.package_path, package_dir);
-        assert_eq!(registry_package.layers(), package.layers());
+            .expect("external package should exist after move");
+        assert_eq!(external_package.package_path, package_dir);
+        assert_eq!(external_package.layers(), package.layers());
 
         std::fs::remove_dir_all(temp_root).unwrap();
     }

--- a/utils/src/config/global_config.rs
+++ b/utils/src/config/global_config.rs
@@ -7,8 +7,11 @@ struct TmpGlobalConfig {
     pub store_dir: String,
     #[serde(default = "default_oocana_dir")]
     pub oocana_dir: String,
-    #[serde(default = "default_registry_store_file")]
-    pub registry_store_file: String,
+    #[serde(
+        default = "default_external_store_file",
+        alias = "registry_store_file"
+    )]
+    pub external_store_file: String,
     pub env_file: Option<String>,
     pub bind_path_file: Option<String>,
     pub search_paths: Option<Vec<String>>,
@@ -22,8 +25,8 @@ fn default_oocana_dir() -> String {
     "~/.oocana".to_string()
 }
 
-fn default_registry_store_file() -> String {
-    "~/.registry/package_store.json".to_string()
+fn default_external_store_file() -> String {
+    "~/.registry/external_store.json".to_string()
 }
 
 impl Default for TmpGlobalConfig {
@@ -31,7 +34,7 @@ impl Default for TmpGlobalConfig {
         TmpGlobalConfig {
             store_dir: default_store_dir(),
             oocana_dir: default_oocana_dir(),
-            registry_store_file: default_registry_store_file(),
+            external_store_file: default_external_store_file(),
             env_file: None,
             bind_path_file: None,
             search_paths: None,
@@ -43,14 +46,14 @@ impl From<TmpGlobalConfig> for GlobalConfig {
     fn from(tmp: TmpGlobalConfig) -> Self {
         let store_dir = expand_home(&tmp.store_dir);
         let oocana_dir = expand_home(&tmp.oocana_dir);
-        let registry_store_file = expand_home(&tmp.registry_store_file);
+        let external_store_file = expand_home(&tmp.external_store_file);
         let env_file = tmp.env_file.map(|s| expand_home(&s));
         let bind_path_file = tmp.bind_path_file.map(|s| expand_home(&s));
 
         GlobalConfig {
             store_dir,
             oocana_dir,
-            registry_store_file,
+            external_store_file,
             env_file,
             bind_path_file,
             search_paths: tmp.search_paths.map(|paths| {
@@ -68,7 +71,7 @@ impl From<TmpGlobalConfig> for GlobalConfig {
 pub struct GlobalConfig {
     pub store_dir: String,
     pub oocana_dir: String,
-    pub registry_store_file: String,
+    pub external_store_file: String,
     pub env_file: Option<String>,
     pub bind_path_file: Option<String>,
     pub search_paths: Option<Vec<String>>,

--- a/utils/src/config/global_config.rs
+++ b/utils/src/config/global_config.rs
@@ -7,10 +7,7 @@ struct TmpGlobalConfig {
     pub store_dir: String,
     #[serde(default = "default_oocana_dir")]
     pub oocana_dir: String,
-    #[serde(
-        default = "default_external_store_file",
-        alias = "registry_store_file"
-    )]
+    #[serde(default = "default_external_store_file", alias = "registry_store_file")]
     pub external_store_file: String,
     pub env_file: Option<String>,
     pub bind_path_file: Option<String>,

--- a/utils/src/config/mod.rs
+++ b/utils/src/config/mod.rs
@@ -20,8 +20,14 @@ pub fn oocana_dir() -> Option<PathBuf> {
     Some(PathBuf::from(global_config.global.oocana_dir.clone()))
 }
 
-pub fn registry_store_file() -> Option<PathBuf> {
+pub fn external_store_file() -> Option<PathBuf> {
     use crate::path::expand_home;
+
+    if let Ok(val) = std::env::var("OOMOL_EXTERNAL_STORE_FILE") {
+        if !val.is_empty() {
+            return Some(PathBuf::from(expand_home(&val)));
+        }
+    }
 
     if let Ok(val) = std::env::var("OOMOL_REGISTRY_STORE_FILE") {
         if !val.is_empty() {
@@ -31,7 +37,7 @@ pub fn registry_store_file() -> Option<PathBuf> {
 
     let global_config = GLOBAL_CONFIG.lock().unwrap();
     Some(PathBuf::from(
-        global_config.global.registry_store_file.clone(),
+        global_config.global.external_store_file.clone(),
     ))
 }
 


### PR DESCRIPTION
## Summary

将 `layer` crate 里的 "registry layer store" 重命名为 "external layer store"。动机：`registry` 与 npm/OCI registry 混淆；`external` 更准确地描述了「通过 name@version 注册、不依赖 package path 的 layer 存储」的语义。

在 API 表面完全改名的同时，通过三层兼容机制保留用户的历史数据 / 配置 / 环境：旧环境变量继续生效、旧配置字段通过 `serde(alias)` 解析、旧磁盘文件首次读取时自动迁移。

## ⚠️ Breaking changes（CLI）

CLI 子命令**彻底改名**，旧命令不再可用：

| 旧命令 | 新命令 |
|--------|--------|
| `oocana package-layer create-registry <pkg> <ver> <path> ...` | `oocana package-layer create-external <pkg> <ver> <path> ...` |
| `oocana package-layer delete-registry <pkg> <ver>` | `oocana package-layer delete-external <pkg> <ver>` |
| `oocana package-layer get-registry <pkg> <ver>` | `oocana package-layer get-external <pkg> <ver>` |

命令的参数、行为、输出格式均不变，**仅名字改变**。任何调用这三个子命令的脚本 / CI / 外部工具需要同步更新。

> 注：`oocana package-layer get` 子命令未改名，其 `--package-name` / `--version` 可选参数仍可复用相同的 lookup fallback 逻辑。

## 行为改动（向后兼容，无需调用方变更）

### 1. 环境变量：新增 `OOMOL_EXTERNAL_STORE_FILE`，旧变量继续生效
- 优先读取 `OOMOL_EXTERNAL_STORE_FILE`
- 若未设置，fallback 到 `OOMOL_REGISTRY_STORE_FILE`
- 两者都未设置时使用全局配置中的路径
- 旧部署脚本无需调整

### 2. 配置文件字段：`registry_store_file` → `external_store_file`（serde alias 兼容）
```yaml
# 新配置
global:
  external_store_file: "~/.registry/external_store.json"

# 旧配置仍可读取（通过 #[serde(alias = "registry_store_file")]）
global:
  registry_store_file: "~/.registry/package_store.json"
```

### 3. 磁盘路径：`~/.registry/package_store.json` → `~/.registry/external_store.json`
- 目录名 `.registry/` **保留不变**
- 文件名从 `package_store.json` 改为 `external_store.json`
- **首次读取时自动迁移**：若新文件不存在但同目录下旧 `package_store.json` 存在，则原子 `rename` 旧 → 新，并打印 info 日志
- 迁移为一次性，之后正常读写新文件
- JSON 内部结构（`version` / `packages` 字段）完全不变，存量数据零感知

### 4. Rust API 重命名（layer crate 的 pub API）
| 旧 API | 新 API |
|--------|--------|
| `layer::RegistryLayerStore` | `layer::ExternalLayerStore` |
| `layer::RegistryLayerStatus` | `layer::ExternalLayerStatus` |
| `layer::create_registry_layer` | `layer::create_external_layer` |
| `layer::delete_registry_layer` | `layer::delete_external_layer` |
| `layer::get_registry_layer` | `layer::get_external_layer` |
| `layer::list_registry_layers` | `layer::list_external_layers` |
| `layer::load_registry_store` | `layer::load_external_store` |
| `layer::registry_layer_status` | `layer::external_layer_status` |
| `utils::config::registry_store_file()` | `utils::config::external_store_file()` |

当前仓库内部调用方（`cli`、`layer/tests`、`runtime_layer`、`package_layer`）已同步迁移。

## Non-changes（显式保持）

- 磁盘目录 `~/.registry/` — 保留
- `ExternalLayerStore` 的 JSON 字段名（`version`、`packages`）— 保留
- `PackageLayer` 结构体 — 未触
- `LayerAction::Create` / `Delete` / `Get` 等其他 package-layer 子命令 — 未触

## Test plan

- [x] `cargo check --workspace --tests` 通过
- [x] `cargo test --workspace --exclude layer` 绿（唯一失败是本地无 mosquitto broker 的 `remote_task_flow`，与本 PR 无关）
- [x] 残留扫描 `rg -i 'registry_layer|registry_store|RegistryLayer|RegistryStore|create-registry|delete-registry|get-registry'` 只剩两处预期保留：env var fallback `"OOMOL_REGISTRY_STORE_FILE"` 和 serde `alias = "registry_store_file"`
- [ ] **CI（Linux）**：完整跑 `cargo test --package layer`（macOS 本地跳过 Linux-only 测试）
- [ ] 手动验证 CLI：在 Linux 环境跑 `oocana package-layer create-external` / `get-external` / `delete-external`
- [ ] 手动验证迁移：构造 `~/.registry/package_store.json` 后运行任意 `oocana package-layer list`，确认 rename 为 `external_store.json` 且内容一致
- [ ] 手动验证旧 env var：`OOMOL_REGISTRY_STORE_FILE=/tmp/x.json oocana package-layer list` 仍能读取该路径