### PR TITLE
feat(layer): skip package-layer handling for @connector packages

### DIFF
--- a/cli/src/layer.rs
+++ b/cli/src/layer.rs
@@ -5,8 +5,8 @@ use crate::fun::arg::{find_env_file, load_bind_paths};
 use clap::Subcommand;
 use manifest_reader::path_finder::find_package_file;
 use manifest_reader::reader::{
-    is_connector_package_name, read_block_metadata, read_package, read_package_identity,
-    should_skip_package_layer_handling, should_skip_package_layer_handling_for_path,
+    read_block_metadata, read_package, read_package_identity, should_skip_package_layer_handling,
+    should_skip_package_layer_handling_for_path,
 };
 use std::io::Write;
 use tracing::info;
@@ -195,9 +195,7 @@ fn package_layer_skip_reason(package_path: &Path) -> Option<&'static str> {
     }
 
     let package_name = read_package_identity(package_path).and_then(|identity| identity.name);
-    if should_skip_package_layer_handling(&metadata, package_name.as_deref())
-        && is_connector_package_name(package_name.as_deref())
-    {
+    if should_skip_package_layer_handling(&metadata, package_name.as_deref()) {
         return Some("package name starts with @connector");
     }
 

--- a/cli/src/layer.rs
+++ b/cli/src/layer.rs
@@ -1,9 +1,13 @@
 use std::collections::HashMap;
+use std::path::Path;
 
 use crate::fun::arg::{find_env_file, load_bind_paths};
 use clap::Subcommand;
 use manifest_reader::path_finder::find_package_file;
-use manifest_reader::reader::read_package;
+use manifest_reader::reader::{
+    is_connector_package_name, read_block_metadata, read_package, read_package_identity,
+    should_skip_package_layer_handling, should_skip_package_layer_handling_for_path,
+};
 use std::io::Write;
 use tracing::info;
 use utils::error::{Error, Result};
@@ -184,6 +188,34 @@ fn get_layer_status_external_first(
     }
 }
 
+fn package_layer_skip_reason(package_path: &Path) -> Option<&'static str> {
+    let metadata = read_block_metadata(package_path);
+    if metadata.hide_source {
+        return Some("hide_source is enabled");
+    }
+
+    let package_name = read_package_identity(package_path).and_then(|identity| identity.name);
+    if should_skip_package_layer_handling(&metadata, package_name.as_deref())
+        && is_connector_package_name(package_name.as_deref())
+    {
+        return Some("package name starts with @connector");
+    }
+
+    None
+}
+
+fn package_layer_status_for_query(
+    package_path: &Path,
+    override_name: Option<&str>,
+    override_version: Option<&str>,
+) -> layer::PackageLayerStatus {
+    if should_skip_package_layer_handling_for_path(package_path) {
+        return layer::PackageLayerStatus::Exist;
+    }
+
+    get_layer_status_external_first(package_path, override_name, override_version)
+}
+
 pub fn layer_action(action: &LayerAction) -> Result<()> {
     if std::env::var(utils::env::OVMLAYER_LOG_ENV_KEY).is_err() {
         std::env::set_var(
@@ -208,11 +240,9 @@ pub fn layer_action(action: &LayerAction) -> Result<()> {
             retain_env_keys,
             env_file,
         } => {
-            if manifest_reader::reader::read_block_metadata(std::path::Path::new(package))
-                .hide_source
-            {
+            if let Some(reason) = package_layer_skip_reason(std::path::Path::new(package)) {
                 return Err(Error::from(format!(
-                    "Cannot create layer for package {package}: hide_source is enabled"
+                    "Cannot create layer for package {package}: {reason}"
                 )));
             }
             let bind_path_arg = load_bind_paths(bind_paths, bind_path_file);
@@ -280,14 +310,12 @@ pub fn layer_action(action: &LayerAction) -> Result<()> {
             package_name,
             version,
         } => {
-            if manifest_reader::reader::read_block_metadata(std::path::Path::new(package))
-                .hide_source
-            {
-                info!("package ({package}) has hide_source enabled, reporting Exist");
-                println!("{:?}", layer::PackageLayerStatus::Exist);
-                return Ok(());
+            if let Some(reason) = package_layer_skip_reason(std::path::Path::new(package)) {
+                info!(
+                    "package ({package}) skips package-layer handling ({reason}), reporting Exist"
+                );
             }
-            let status = get_layer_status_external_first(
+            let status = package_layer_status_for_query(
                 std::path::Path::new(package),
                 package_name.as_deref(),
                 version.as_deref(),
@@ -334,39 +362,29 @@ pub fn layer_action(action: &LayerAction) -> Result<()> {
                                 }
 
                                 if find_package_file(&scope_path).is_some() {
-                                    if manifest_reader::reader::read_block_metadata(&scope_path)
-                                        .hide_source
-                                    {
+                                    if let Some(reason) = package_layer_skip_reason(&scope_path) {
                                         info!(
-                                            "package ({}) has hide_source enabled, reporting Exist",
-                                            scope_path.display()
+                                            "package ({}) skips package-layer handling ({}), reporting Exist",
+                                            scope_path.display(),
+                                            reason
                                         );
-                                        package_map.insert(
-                                            scope_path,
-                                            format!("{:?}", layer::PackageLayerStatus::Exist),
-                                        );
-                                        continue;
                                     }
                                     let status =
-                                        get_layer_status_external_first(&scope_path, None, None);
+                                        package_layer_status_for_query(&scope_path, None, None);
                                     package_map.insert(scope_path, format!("{status:?}"));
                                 }
                             }
                         } else {
                             // Regular directories, use original logic
                             if find_package_file(&path).is_some() {
-                                if manifest_reader::reader::read_block_metadata(&path).hide_source {
+                                if let Some(reason) = package_layer_skip_reason(&path) {
                                     info!(
-                                        "package ({}) has hide_source enabled, reporting Exist",
-                                        path.display()
+                                        "package ({}) skips package-layer handling ({}), reporting Exist",
+                                        path.display(),
+                                        reason
                                     );
-                                    package_map.insert(
-                                        path,
-                                        format!("{:?}", layer::PackageLayerStatus::Exist),
-                                    );
-                                    continue;
                                 }
-                                let status = get_layer_status_external_first(&path, None, None);
+                                let status = package_layer_status_for_query(&path, None, None);
                                 package_map.insert(path, format!("{status:?}"));
                             }
                         }
@@ -462,4 +480,51 @@ pub fn layer_action(action: &LayerAction) -> Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn workspace_root() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("..")
+            .canonicalize()
+            .unwrap()
+    }
+
+    #[test]
+    fn connector_packages_are_rejected_for_package_layer_create() {
+        let package = workspace_root().join("tests/fixtures/@connector/demo");
+
+        assert_eq!(
+            package_layer_skip_reason(&package),
+            Some("package name starts with @connector")
+        );
+    }
+
+    #[test]
+    fn connector_packages_report_exist_for_layer_queries() {
+        let package = workspace_root().join("tests/fixtures/@connector/demo");
+
+        assert_eq!(
+            package_layer_status_for_query(&package, None, None),
+            layer::PackageLayerStatus::Exist
+        );
+    }
+
+    #[test]
+    fn hide_source_packages_still_report_exist_for_layer_queries() {
+        let package = workspace_root().join("examples/remote_task/hide-example");
+
+        assert_eq!(
+            package_layer_skip_reason(&package),
+            Some("hide_source is enabled")
+        );
+        assert_eq!(
+            package_layer_status_for_query(&package, None, None),
+            layer::PackageLayerStatus::Exist
+        );
+    }
 }

--- a/layer/src/package_layer.rs
+++ b/layer/src/package_layer.rs
@@ -9,8 +9,7 @@ use crate::layer::{
 };
 use crate::ovmlayer::{BindPath, cp_to_layer};
 use crate::package_store::{add_import_package, get_package_layer, remove_package_from_store};
-use manifest_reader::path_finder::find_package_file;
-use manifest_reader::reader::read_package;
+use manifest_reader::reader::read_package_identity;
 use serde::{Deserialize, Serialize};
 use tracing::instrument;
 use utils::error::Result;
@@ -52,9 +51,7 @@ pub struct PackageLayer {
 }
 
 fn read_package_name(package_path: &std::path::Path) -> Option<String> {
-    find_package_file(package_path)
-        .and_then(|package_file| read_package(&package_file).ok())
-        .and_then(|pkg| pkg.name)
+    read_package_identity(package_path).and_then(|pkg| pkg.name)
 }
 
 impl PackageLayer {

--- a/manifest_reader/src/reader.rs
+++ b/manifest_reader/src/reader.rs
@@ -74,7 +74,7 @@ pub fn read_package_identity(package_path: &Path) -> Option<PackageIdentity> {
 }
 
 pub fn is_connector_package_name(package_name: Option<&str>) -> bool {
-    package_name.is_some_and(|name| name.starts_with("@connector"))
+    package_name.is_some_and(|name| name == "@connector" || name.starts_with("@connector/"))
 }
 
 pub fn should_skip_package_layer_handling(

--- a/manifest_reader/src/reader.rs
+++ b/manifest_reader/src/reader.rs
@@ -4,6 +4,7 @@ use serde::de::DeserializeOwned;
 use utils::error::Result;
 
 use crate::manifest::{InputHandles, PackageMeta, Service, SubflowBlock, TaskBlock};
+use crate::path_finder::find_package_file;
 use path_clean::PathClean;
 
 pub fn read_task_block(task_manifest_path: &Path) -> Result<TaskBlock> {
@@ -55,6 +56,39 @@ pub fn read_package<P: AsRef<Path>>(file_path: P) -> Result<PackageMeta> {
             Box::new(err),
         )
     })
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PackageIdentity {
+    pub name: Option<String>,
+    pub version: Option<String>,
+}
+
+pub fn read_package_identity(package_path: &Path) -> Option<PackageIdentity> {
+    find_package_file(package_path)
+        .and_then(|package_file| read_package(&package_file).ok())
+        .map(|package| PackageIdentity {
+            name: package.name,
+            version: package.version,
+        })
+}
+
+pub fn is_connector_package_name(package_name: Option<&str>) -> bool {
+    package_name.is_some_and(|name| name.starts_with("@connector"))
+}
+
+pub fn should_skip_package_layer_handling(
+    metadata: &BlockMetadata,
+    package_name: Option<&str>,
+) -> bool {
+    metadata.hide_source || is_connector_package_name(package_name)
+}
+
+pub fn should_skip_package_layer_handling_for_path(package_path: &Path) -> bool {
+    let metadata = read_block_metadata(package_path);
+    let package_name = read_package_identity(package_path).and_then(|identity| identity.name);
+
+    should_skip_package_layer_handling(&metadata, package_name.as_deref())
 }
 
 pub fn read_service(service_manifest_path: &Path) -> Result<Service> {

--- a/runtime/src/flow_job/block_request.rs
+++ b/runtime/src/flow_job/block_request.rs
@@ -196,7 +196,7 @@ pub fn parse_run_block_request(
                     RuntimeScope {
                         session_id: shared.session_id.clone(),
                         pkg_name: Some(pkg_name.clone()),
-                        data_dir: scope.pkg_root.join(pkg_name).to_string_lossy().to_string(),
+                        data_dir: scope.pkg_root.join(&pkg_name).to_string_lossy().to_string(),
                         pkg_root: scope.pkg_root.clone(),
                         path: task_block.package_path.clone().unwrap_or_else(|| {
                             // if package path is not set, use flow shared scope package path
@@ -206,10 +206,8 @@ pub fn parse_run_block_request(
                         node_id: None,
                         is_inject: false,
                         enable_layer: crate::shared::package_scope_enable_layer(
-                            task_block
-                                .package_path
-                                .as_deref()
-                                .unwrap_or(scope.path.as_path()),
+                            task_block.hide_source,
+                            Some(pkg_name.as_str()),
                         ),
                     }
                 }
@@ -233,7 +231,7 @@ pub fn parse_run_block_request(
                 BlockValueType::Pkg { pkg_name, .. } => RuntimeScope {
                     session_id: shared.session_id.clone(),
                     pkg_name: Some(pkg_name.clone()),
-                    data_dir: scope.pkg_root.join(pkg_name).to_string_lossy().to_string(),
+                    data_dir: scope.pkg_root.join(&pkg_name).to_string_lossy().to_string(),
                     pkg_root: scope.pkg_root.clone(),
                     path: subflow_guard.package_path.clone().unwrap_or_else(|| {
                         warn!("can not find subflow package path, this should never happen");
@@ -242,10 +240,8 @@ pub fn parse_run_block_request(
                     node_id: None,
                     is_inject: false,
                     enable_layer: crate::shared::package_scope_enable_layer(
-                        subflow_guard
-                            .package_path
-                            .as_deref()
-                            .unwrap_or(scope.path.as_path()),
+                        subflow_guard.hide_source,
+                        Some(pkg_name.as_str()),
                     ),
                 },
                 _ => scope.clone(),

--- a/runtime/src/flow_job/block_request.rs
+++ b/runtime/src/flow_job/block_request.rs
@@ -205,7 +205,12 @@ pub fn parse_run_block_request(
                         }),
                         node_id: None,
                         is_inject: false,
-                        enable_layer: !task_block.hide_source && layer::feature_enabled(),
+                        enable_layer: crate::shared::package_scope_enable_layer(
+                            task_block
+                                .package_path
+                                .as_deref()
+                                .unwrap_or(scope.path.as_path()),
+                        ),
                     }
                 }
                 _ => scope.clone(),
@@ -236,7 +241,12 @@ pub fn parse_run_block_request(
                     }),
                     node_id: None,
                     is_inject: false,
-                    enable_layer: !subflow_guard.hide_source && layer::feature_enabled(),
+                    enable_layer: crate::shared::package_scope_enable_layer(
+                        subflow_guard
+                            .package_path
+                            .as_deref()
+                            .unwrap_or(scope.path.as_path()),
+                    ),
                 },
                 _ => scope.clone(),
             };

--- a/runtime/src/flow_job/flow.rs
+++ b/runtime/src/flow_job/flow.rs
@@ -1124,7 +1124,7 @@ fn run_node(node: &Node, shared: &FlowShared, ctx: &mut RunFlowContext) {
                 .to_string(),
             pkg_root: shared.scope.pkg_root.clone(),
             node_id: node_id.clone(),
-            enable_layer: !node.hide_source() && layer::feature_enabled(),
+            enable_layer: crate::shared::package_scope_enable_layer(&path),
             is_inject: node.scope().is_inject(),
         },
         BlockScope::Flow { node_id, .. } => RuntimeScope {

--- a/runtime/src/flow_job/flow.rs
+++ b/runtime/src/flow_job/flow.rs
@@ -1119,12 +1119,15 @@ fn run_node(node: &Node, shared: &FlowShared, ctx: &mut RunFlowContext) {
             data_dir: shared
                 .scope
                 .pkg_root
-                .join(name)
+                .join(&name)
                 .to_string_lossy()
                 .to_string(),
             pkg_root: shared.scope.pkg_root.clone(),
             node_id: node_id.clone(),
-            enable_layer: crate::shared::package_scope_enable_layer(&path),
+            enable_layer: crate::shared::package_scope_enable_layer(
+                node.hide_source(),
+                Some(name.as_str()),
+            ),
             is_inject: node.scope().is_inject(),
         },
         BlockScope::Flow { node_id, .. } => RuntimeScope {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -573,12 +573,6 @@ pub fn get_packages(args: GetPackageArgs<'_>) -> Result<HashMap<PathBuf, String>
                         filter_nodes.is_empty() || filter_nodes.contains(&node.0.to_string())
                     })
                     .for_each(|node| {
-                        // NOTE: hide_source nodes are skipped here so they won't be
-                        // included in layer status queries. However, this only covers
-                        // top-level nodes; nested subflow nodes are not checked here.
-                        if node.1.hide_source() {
-                            return;
-                        }
                         if let Some(package_path) = node.1.package_path() {
                             packages.push(package_path);
                         }
@@ -596,6 +590,10 @@ pub fn get_packages(args: GetPackageArgs<'_>) -> Result<HashMap<PathBuf, String>
 
     let mut package_layers = HashMap::new();
     packages.iter().for_each(|package| {
+        if manifest_reader::reader::should_skip_package_layer_handling_for_path(package) {
+            package_layers.insert(package.clone(), "true".to_owned());
+            return;
+        }
         let layers = layer::package_layer_status(package);
         if let Ok(layer::PackageLayerStatus::Exist) = layers {
             package_layers.insert(package.clone(), "true".to_owned());
@@ -835,6 +833,28 @@ mod tests {
                 None
             }
         })
+    }
+
+    #[test]
+    fn get_packages_reports_connector_packages_as_enabled() {
+        let root = project_root();
+        let flow_path = root.join("tests/fixtures/query-connector-package");
+        let search_path = root.join("tests/fixtures");
+
+        let packages = get_packages(GetPackageArgs {
+            block: flow_path.to_str().unwrap(),
+            block_reader: BlockResolver::new(),
+            path_finder: BlockPathFinder::new(root, Some(vec![search_path])),
+            nodes: None,
+        })
+        .expect("query package should succeed");
+
+        let connector_package = project_root()
+            .join("tests/fixtures/@connector/demo")
+            .canonicalize()
+            .unwrap();
+
+        assert_eq!(packages.get(&connector_package), Some(&"true".to_string()));
     }
 
     #[tokio::test]

--- a/runtime/src/shared.rs
+++ b/runtime/src/shared.rs
@@ -1,6 +1,7 @@
 use job::SessionId;
 
 use mainframe::{reporter::ReporterTx, scheduler::SchedulerTx};
+use std::path::Path;
 
 use crate::delay_abort::DelayAbortTx;
 use crate::remote_task_config::RemoteTaskConfig;
@@ -15,4 +16,47 @@ pub struct Shared {
     pub reporter: ReporterTx,
     pub use_cache: bool,
     pub remote_task_config: Option<RemoteTaskConfig>,
+}
+
+pub(crate) fn should_enable_package_layer(package_path: &Path, feature_enabled: bool) -> bool {
+    feature_enabled
+        && !manifest_reader::reader::should_skip_package_layer_handling_for_path(package_path)
+}
+
+pub(crate) fn package_scope_enable_layer(package_path: &Path) -> bool {
+    should_enable_package_layer(package_path, layer::feature_enabled())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn workspace_root() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("..")
+            .canonicalize()
+            .unwrap()
+    }
+
+    #[test]
+    fn connector_packages_disable_package_layer_even_when_feature_is_enabled() {
+        let package = workspace_root().join("tests/fixtures/@connector/demo");
+
+        assert!(!should_enable_package_layer(&package, true));
+    }
+
+    #[test]
+    fn hide_source_packages_disable_package_layer_even_when_feature_is_enabled() {
+        let package = workspace_root().join("examples/remote_task/hide-example");
+
+        assert!(!should_enable_package_layer(&package, true));
+    }
+
+    #[test]
+    fn regular_packages_still_enable_package_layer_when_feature_is_enabled() {
+        let package = workspace_root().join("examples/base/pkg_a");
+
+        assert!(should_enable_package_layer(&package, true));
+    }
 }

--- a/runtime/src/shared.rs
+++ b/runtime/src/shared.rs
@@ -1,7 +1,6 @@
 use job::SessionId;
 
 use mainframe::{reporter::ReporterTx, scheduler::SchedulerTx};
-use std::path::Path;
 
 use crate::delay_abort::DelayAbortTx;
 use crate::remote_task_config::RemoteTaskConfig;
@@ -18,45 +17,58 @@ pub struct Shared {
     pub remote_task_config: Option<RemoteTaskConfig>,
 }
 
-pub(crate) fn should_enable_package_layer(package_path: &Path, feature_enabled: bool) -> bool {
+pub(crate) fn should_enable_package_layer(
+    hide_source: bool,
+    package_name: Option<&str>,
+    feature_enabled: bool,
+) -> bool {
     feature_enabled
-        && !manifest_reader::reader::should_skip_package_layer_handling_for_path(package_path)
+        && !manifest_reader::reader::should_skip_package_layer_handling(
+            &manifest_reader::reader::BlockMetadata {
+                hide_source,
+                timeout: None,
+            },
+            package_name,
+        )
 }
 
-pub(crate) fn package_scope_enable_layer(package_path: &Path) -> bool {
-    should_enable_package_layer(package_path, layer::feature_enabled())
+pub(crate) fn package_scope_enable_layer(hide_source: bool, package_name: Option<&str>) -> bool {
+    should_enable_package_layer(hide_source, package_name, layer::feature_enabled())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::path::PathBuf;
-
-    fn workspace_root() -> PathBuf {
-        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-            .join("..")
-            .canonicalize()
-            .unwrap()
-    }
 
     #[test]
     fn connector_packages_disable_package_layer_even_when_feature_is_enabled() {
-        let package = workspace_root().join("tests/fixtures/@connector/demo");
-
-        assert!(!should_enable_package_layer(&package, true));
+        assert!(!should_enable_package_layer(
+            false,
+            Some("@connector/demo"),
+            true
+        ));
     }
 
     #[test]
     fn hide_source_packages_disable_package_layer_even_when_feature_is_enabled() {
-        let package = workspace_root().join("examples/remote_task/hide-example");
-
-        assert!(!should_enable_package_layer(&package, true));
+        assert!(!should_enable_package_layer(
+            true,
+            Some("regular-pkg"),
+            true
+        ));
     }
 
     #[test]
     fn regular_packages_still_enable_package_layer_when_feature_is_enabled() {
-        let package = workspace_root().join("examples/base/pkg_a");
+        assert!(should_enable_package_layer(false, Some("pkg_a"), true));
+    }
 
-        assert!(should_enable_package_layer(&package, true));
+    #[test]
+    fn connector_prefix_must_match_scope_boundary() {
+        assert!(should_enable_package_layer(
+            false,
+            Some("@connectorx/demo"),
+            true
+        ));
     }
 }

--- a/tests/fixtures/@connector/demo/package.oo.yaml
+++ b/tests/fixtures/@connector/demo/package.oo.yaml
@@ -1,0 +1,2 @@
+name: "@connector/demo"
+version: 0.1.0

--- a/tests/fixtures/@connector/demo/tasks/echo/task.oo.yaml
+++ b/tests/fixtures/@connector/demo/tasks/echo/task.oo.yaml
@@ -1,0 +1,7 @@
+type: task_block
+executor:
+  name: rust
+inputs_def:
+  - handle: message
+outputs_def:
+  - handle: echoed

--- a/tests/fixtures/query-connector-package/flow.oo.yaml
+++ b/tests/fixtures/query-connector-package/flow.oo.yaml
@@ -1,0 +1,7 @@
+name: query-connector-package
+nodes:
+  - node_id: connector-task
+    task: "@connector/demo::echo"
+    inputs_from:
+      - handle: message
+        value: "hello"

--- a/tests/test_query.rs
+++ b/tests/test_query.rs
@@ -56,6 +56,37 @@ fn query_inputs() {
 }
 
 #[test]
+fn query_package_reports_connector_package_as_enabled() {
+    let output = oocana_cmd()
+        .args([
+            "query",
+            "package",
+            "tests/fixtures/query-connector-package",
+            "--search-paths",
+            "tests/fixtures",
+        ])
+        .output()
+        .expect("failed to run oocana query package");
+
+    assert!(
+        output.status.success(),
+        "query package failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    let connector_package = std::fs::canonicalize("tests/fixtures/@connector/demo")
+        .expect("connector fixture package should exist");
+    let expected = format!("package-status: {:?}:\"true\"", connector_package);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(
+        stdout.contains(&expected),
+        "expected query output to contain {expected:?}, got:\n{stdout}"
+    );
+}
+
+#[test]
 fn query_nodes_inputs() {
     let result = query_to_json(
         &["query", "nodes-inputs", "examples/input"],


### PR DESCRIPTION
## Summary
- add shared package identity and package-layer skip helpers for hide_source and `@connector` packages
- apply the package-layer-only skip logic to package-layer create/get/scan, runtime package scopes, and package query reporting
- add connector fixtures and regression coverage so `@connector` packages report layer existence without affecting create-external or remote execution

## Testing
- cargo test -p cli --lib layer::tests
- cargo test -p runtime shared::tests
- cargo test -p runtime connector_packages
- cargo test --test test_query query_package_reports_connector_package_as_enabled