### PR TITLE
fix(runtime): finish block on executor failure

### DIFF
--- a/mainframe/src/scheduler.rs
+++ b/mainframe/src/scheduler.rs
@@ -970,18 +970,8 @@ fn spawn_executor(
                     Some(state) if state.spawn_state == ExecutorSpawnState::TimedOut => {
                         state.pid = None;
                     }
-                    Some(state) => {
-                        state.spawn_state = ExecutorSpawnState::Finished;
-                        state.pid = None;
-                    }
-                    None => {
-                        write_map.insert(
-                            executor_map_name_clone.clone(),
-                            ExecutorState {
-                                spawn_state: ExecutorSpawnState::Finished,
-                                pid: None,
-                            },
-                        );
+                    _ => {
+                        write_map.remove(&executor_map_name_clone);
                     }
                 }
                 drop(write_map);
@@ -1050,7 +1040,7 @@ fn query_executor_state(params: ExecutorCheckParams) -> Result<ExecutorCheckResu
 
     let executor_map_name = generate_executor_map_name(executor_name, scope);
 
-    let executor_state = {
+    let mut executor_state = {
         let read_map = executor_map
             .read()
             .map_err(|_| Error::new("Failed to acquire read lock"))?;
@@ -1060,6 +1050,14 @@ fn query_executor_state(params: ExecutorCheckParams) -> Result<ExecutorCheckResu
             .unwrap_or_default()
             .spawn_state
     };
+
+    if executor_state == ExecutorSpawnState::Finished {
+        let mut write_map = executor_map
+            .write()
+            .map_err(|_| Error::new("Failed to acquire write lock"))?;
+        write_map.remove(&executor_map_name);
+        executor_state = ExecutorSpawnState::None;
+    }
 
     if executor_state == ExecutorSpawnState::TimedOut {
         return Err(Error::new(&format!(
@@ -2266,5 +2264,30 @@ mod tests {
 
         scheduler_tx.abort();
         scheduler_handle.await.unwrap();
+    }
+
+    #[test]
+    fn finished_executor_state_allows_restart() {
+        let session_id = SessionId::random();
+        let scope = test_scope(session_id, "restart");
+        let executor_map = Arc::new(RwLock::new(HashMap::from([(
+            generate_executor_map_name("python", &scope),
+            ExecutorState {
+                spawn_state: ExecutorSpawnState::Finished,
+                pid: None,
+            },
+        )])));
+
+        let result = query_executor_state(ExecutorCheckParams {
+            executor_name: "python",
+            scope: &scope,
+            injection_store: &None,
+            flow_path: &None,
+            executor_payload: &test_executor_payload(scope.session_id.clone()),
+            executor_map,
+        })
+        .unwrap();
+
+        assert_eq!(result.executor_state, ExecutorSpawnState::None);
     }
 }

--- a/mainframe/src/scheduler.rs
+++ b/mainframe/src/scheduler.rs
@@ -370,6 +370,7 @@ enum SchedulerCommand {
     },
     ExecutorExit {
         executor: String,
+        identifier: Option<String>,
         code: i32,
         reason: Option<String>,
     },
@@ -386,6 +387,20 @@ enum SchedulerCommand {
 pub struct ExecutorState {
     spawn_state: ExecutorSpawnState,
     pid: Option<u32>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RunningBlock {
+    executor_name: String,
+    identifier: String,
+}
+
+fn executor_name_matches(running_executor: &str, exited_executor: &str) -> bool {
+    fn trim_executor_suffix(executor: &str) -> &str {
+        executor.strip_suffix("-executor").unwrap_or(executor)
+    }
+
+    trim_executor_suffix(running_executor) == trim_executor_suffix(exited_executor)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
@@ -871,7 +886,7 @@ fn spawn_executor(
 
     let executor_bin_clone = executor_bin.clone();
     let executor_map_name_clone = executor_map_name.clone();
-    let identifier_clone = identifier.clone();
+    let identifier_for_timeout = identifier.clone();
     tokio::spawn(async move {
         tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
         {
@@ -886,7 +901,7 @@ fn spawn_executor(
             if let Err(e) = txx.send(SchedulerCommand::SpawnExecutorTimeout {
                 executor: executor_bin_clone,
                 package: executor_package,
-                identifier: Some(identifier_clone),
+                identifier: Some(identifier_for_timeout),
             }) {
                 warn!("Scheduler send spawn executor timeout failed: {e}");
             }
@@ -923,16 +938,21 @@ fn spawn_executor(
             if let Some(stderr) = ch.stderr.take() {
                 let mut reader = tokio::io::BufReader::new(stderr).lines();
                 let executor_bin_clone = executor_bin.clone();
+                let identifier_clone = identifier.clone();
 
                 tokio::spawn(async move {
                     while let Ok(Some(line)) = reader.next_line().await {
-                        debug!("{} ({}) stderr: {}", executor_bin_clone, identifier, line);
+                        debug!(
+                            "{} ({}) stderr: {}",
+                            executor_bin_clone, identifier_clone, line
+                        );
                     }
                 });
             }
             let executor_bin_clone = executor_bin;
             let executor_map_clone = executor_map.clone();
             let executor_map_name_clone = executor_map_name.clone();
+            let identifier_for_exit = identifier.clone();
 
             tokio::spawn(async move {
                 let status = ch.wait().await;
@@ -958,6 +978,7 @@ fn spawn_executor(
                         if !status.success() {
                             let _ = tx.send(SchedulerCommand::ExecutorExit {
                                 executor: executor_bin_clone.clone(),
+                                identifier: Some(identifier_for_exit.clone()),
                                 code,
                                 reason: None,
                             });
@@ -967,6 +988,7 @@ fn spawn_executor(
                         error!("wait {} error: {:?}", executor_bin_clone, e);
                         let _ = tx.send(SchedulerCommand::ExecutorExit {
                             executor: executor_bin_clone.clone(),
+                            identifier: Some(identifier_for_exit.clone()),
                             code: -1,
                             reason: Some(format!("{e}")),
                         });
@@ -1149,6 +1171,7 @@ where
             mut impl_rx,
         } = self;
 
+        let mut running_blocks: HashMap<JobId, RunningBlock> = HashMap::new();
         let session_id = executor_payload.session_id.clone();
         let tx_clone = tx.clone();
 
@@ -1253,6 +1276,14 @@ where
                         service_hash,
                         flow_path,
                     }) => {
+                        running_blocks.insert(
+                            job_id.clone(),
+                            RunningBlock {
+                                executor_name: executor_name.clone(),
+                                identifier: scope.identifier(),
+                            },
+                        );
+
                         let result = query_executor_state(ExecutorCheckParams {
                             executor_name: &executor_name,
                             scope: &scope,
@@ -1265,6 +1296,7 @@ where
                         if let Err(e) = result {
                             if let Err(e) = tx.send(SchedulerCommand::ExecutorExit {
                                 executor: executor_name.clone(),
+                                identifier: Some(scope.identifier()),
                                 code: -1,
                                 reason: Some(format!("{e:?}")),
                             }) {
@@ -1297,6 +1329,7 @@ where
                             if let Err(e) = r {
                                 if let Err(e) = tx.send(SchedulerCommand::ExecutorExit {
                                     executor: executor_name.clone(),
+                                    identifier: Some(scope.identifier()),
                                     code: -1,
                                     reason: Some(format!("{e:?}")),
                                 }) {
@@ -1337,6 +1370,14 @@ where
                         injection_store,
                         flow_path,
                     }) => {
+                        running_blocks.insert(
+                            job_id.clone(),
+                            RunningBlock {
+                                executor_name: executor_name.clone(),
+                                identifier: scope.identifier(),
+                            },
+                        );
+
                         let result = query_executor_state(ExecutorCheckParams {
                             executor_name: &executor_name,
                             scope: &scope,
@@ -1349,6 +1390,7 @@ where
                         if let Err(e) = result {
                             let _ = tx.send(SchedulerCommand::ExecutorExit {
                                 executor: executor_name.clone(),
+                                identifier: Some(scope.identifier()),
                                 code: -1,
                                 reason: Some(format!("{e}")),
                             });
@@ -1380,6 +1422,7 @@ where
                             if let Err(e) = r {
                                 if let Err(e) = tx.send(SchedulerCommand::ExecutorExit {
                                     executor: executor_name.clone(),
+                                    identifier: Some(scope.identifier()),
                                     code: -1,
                                     reason: Some(format!("{e}")),
                                 }) {
@@ -1430,6 +1473,44 @@ where
                         package,
                         identifier,
                     }) => {
+                        let error_message = format!(
+                            "Executor {executor} identifier {identifier:?} for package {package:?} timeout after 5s"
+                        );
+                        let finished_jobs = running_blocks
+                            .iter()
+                            .filter_map(|(job_id, running_block)| {
+                                if !executor_name_matches(&running_block.executor_name, &executor) {
+                                    return None;
+                                }
+                                if identifier
+                                    .as_ref()
+                                    .is_some_and(|id| id != &running_block.identifier)
+                                {
+                                    return None;
+                                }
+                                Some(job_id.clone())
+                            })
+                            .collect::<Vec<_>>();
+
+                        for job_id in finished_jobs {
+                            running_blocks.remove(&job_id);
+                            let event = ReceiveMessage::BlockFinished {
+                                session_id: session_id.clone(),
+                                job_id: job_id.clone(),
+                                result: None,
+                                error: Some(error_message.clone()),
+                            };
+                            let data = serde_json::to_vec(&event).unwrap();
+                            impl_tx.send_block_event(&session_id, data).await;
+                            if let Some(sender) = subscribers.get(&job_id) {
+                                if let Err(e) = sender.send(event) {
+                                    warn!(
+                                        "Scheduler send executor timeout block finish to subscriber failed: {e}"
+                                    );
+                                }
+                            }
+                        }
+
                         subscribers.retain(|_, sender| {
                             if let Err(e) = sender.send(ReceiveMessage::ExecutorTimeout {
                                 session_id: session_id.clone(),
@@ -1446,9 +1527,43 @@ where
                     }
                     Ok(SchedulerCommand::ExecutorExit {
                         executor,
+                        identifier,
                         code,
                         reason,
                     }) => {
+                        let error_message = reason
+                            .clone()
+                            .unwrap_or(format!("Executor {executor} exit with code {code}"));
+                        let finished_jobs = running_blocks
+                            .iter()
+                            .filter(|(_, running_block)| {
+                                executor_name_matches(&running_block.executor_name, &executor)
+                                    && identifier
+                                        .as_ref()
+                                        .is_none_or(|id| id == &running_block.identifier)
+                            })
+                            .map(|(job_id, _)| job_id.clone())
+                            .collect::<Vec<_>>();
+
+                        for job_id in finished_jobs {
+                            running_blocks.remove(&job_id);
+                            let event = ReceiveMessage::BlockFinished {
+                                session_id: session_id.clone(),
+                                job_id: job_id.clone(),
+                                result: None,
+                                error: Some(error_message.clone()),
+                            };
+                            let data = serde_json::to_vec(&event).unwrap();
+                            impl_tx.send_block_event(&session_id, data).await;
+                            if let Some(sender) = subscribers.get(&job_id) {
+                                if let Err(e) = sender.send(event) {
+                                    warn!(
+                                        "Scheduler send executor exit block finish to subscriber failed: {e}"
+                                    );
+                                }
+                            }
+                        }
+
                         // 理论上有任意一个 block 处理就 OK
                         subscribers.retain(|_, sender| {
                             if let Err(e) = sender.send(ReceiveMessage::ExecutorExit {
@@ -1531,6 +1646,9 @@ where
                                     }
                                 }
                                 _ => {
+                                    if let ReceiveMessage::BlockFinished { job_id, .. } = &msg {
+                                        running_blocks.remove(job_id);
+                                    }
                                     if let Some(job_id) = msg.job_id().cloned() {
                                         if let Some(sender) = subscribers.get(&job_id) {
                                             if let Err(e) = sender.send(msg) {
@@ -1643,6 +1761,11 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::MessageData;
+    use async_trait::async_trait;
+    use job::SessionId;
+    use std::path::PathBuf;
+    use tokio::time::{Duration, timeout};
 
     #[test]
     fn test_output_options() {
@@ -1659,5 +1782,288 @@ mod tests {
                 })
             })
         }));
+    }
+
+    struct CaptureSchedulerTx {
+        block_events: Sender<ReceiveMessage>,
+    }
+
+    #[async_trait]
+    impl SchedulerTxImpl for CaptureSchedulerTx {
+        async fn send_block_event(&self, _session_id: &SessionId, data: MessageData) {
+            let event = serde_json::from_slice::<ReceiveMessage>(&data).unwrap();
+            self.block_events.send_async(event).await.unwrap();
+        }
+
+        async fn send_inputs(&self, _job_id: &JobId, _data: MessageData) {}
+
+        async fn run_block(&self, _executor_name: &str, _data: MessageData) {}
+
+        async fn respond_block_request(
+            &self,
+            _session_id: &SessionId,
+            _request_id: &str,
+            _data: MessageData,
+        ) {
+        }
+
+        async fn run_service_block(&self, _executor_name: &str, _data: MessageData) {}
+
+        async fn disconnect(&self) {}
+    }
+
+    struct PendingSchedulerRx;
+
+    #[async_trait]
+    impl SchedulerRxImpl for PendingSchedulerRx {
+        async fn recv(&mut self) -> MessageData {
+            std::future::pending::<MessageData>().await
+        }
+    }
+
+    fn test_executor_payload(session_id: SessionId) -> ExecutorParameters {
+        ExecutorParameters {
+            addr: "127.0.0.1:0".to_string(),
+            session_id,
+            session_dir: std::env::temp_dir().display().to_string(),
+            pass_through_env_keys: vec![],
+            bind_paths: vec![],
+            env_file: None,
+            tmp_dir: std::env::temp_dir(),
+            debug: false,
+            wait_for_client: false,
+        }
+    }
+
+    fn test_scope(session_id: SessionId, node_id: &str) -> RuntimeScope {
+        let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("..")
+            .canonicalize()
+            .unwrap();
+        RuntimeScope {
+            session_id,
+            pkg_name: None,
+            data_dir: root.display().to_string(),
+            pkg_root: root.clone(),
+            path: root,
+            node_id: Some(NodeId::from(node_id.to_string())),
+            is_inject: false,
+            enable_layer: false,
+        }
+    }
+
+    #[tokio::test]
+    async fn executor_exit_sends_block_finished_for_running_block() {
+        let session_id = SessionId::random();
+        let job_id = JobId::random();
+        let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("..")
+            .canonicalize()
+            .unwrap();
+        let scope = RuntimeScope {
+            session_id: session_id.clone(),
+            pkg_name: None,
+            data_dir: root.display().to_string(),
+            pkg_root: root.clone(),
+            path: root,
+            node_id: None,
+            is_inject: false,
+            enable_layer: false,
+        };
+        let executor: TaskBlockExecutor = serde_json::from_value(
+            serde_json::json!({"name":"python","options":{"entry":"main.py"}}),
+        )
+        .unwrap();
+        let (block_event_tx, block_event_rx) = flume::unbounded();
+        let (scheduler_tx, scheduler_rx) = create(
+            CaptureSchedulerTx {
+                block_events: block_event_tx,
+            },
+            PendingSchedulerRx,
+            None,
+            None,
+            test_executor_payload(session_id.clone()),
+            scope.data_dir.clone(),
+        );
+
+        scheduler_rx.executor_map.write().unwrap().insert(
+            generate_executor_map_name("python", &scope),
+            ExecutorState {
+                spawn_state: ExecutorSpawnState::Ready,
+                pid: None,
+            },
+        );
+        let scheduler_handle = scheduler_rx.event_loop();
+
+        let (subscriber_tx, subscriber_rx) = flume::unbounded();
+        scheduler_tx.register_subscriber(job_id.clone(), subscriber_tx);
+        scheduler_tx
+            .tx
+            .send(SchedulerCommand::ExecuteBlock {
+                job_id: job_id.clone(),
+                executor_name: "python".to_string(),
+                dir: scope.data_dir.clone(),
+                stacks: vec![],
+                outputs: None,
+                executor,
+                injection_store: None,
+                scope: scope.clone(),
+                flow_path: None,
+            })
+            .unwrap();
+        scheduler_tx
+            .tx
+            .send(SchedulerCommand::ExecutorExit {
+                executor: "python-executor".to_string(),
+                identifier: Some(scope.identifier()),
+                code: 1,
+                reason: None,
+            })
+            .unwrap();
+
+        let subscriber_event = timeout(Duration::from_secs(1), subscriber_rx.recv_async())
+            .await
+            .expect("subscriber should receive synthesized finish")
+            .unwrap();
+        assert!(matches!(
+            subscriber_event,
+            ReceiveMessage::BlockFinished {
+                job_id: ref finished_job_id,
+                error: Some(ref error),
+                ..
+            } if finished_job_id == &job_id
+                && error == "Executor python-executor exit with code 1"
+        ));
+
+        let block_event = timeout(Duration::from_secs(1), block_event_rx.recv_async())
+            .await
+            .expect("broker block event should receive synthesized finish")
+            .unwrap();
+        assert!(matches!(
+            block_event,
+            ReceiveMessage::BlockFinished {
+                job_id: ref finished_job_id,
+                error: Some(ref error),
+                ..
+            } if finished_job_id == &job_id
+                && error == "Executor python-executor exit with code 1"
+        ));
+
+        scheduler_tx.abort();
+        scheduler_handle.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn executor_exit_only_finishes_matching_identifier() {
+        let session_id = SessionId::random();
+        let matching_job_id = JobId::random();
+        let other_job_id = JobId::random();
+        let matching_scope = test_scope(session_id.clone(), "matching");
+        let other_scope = test_scope(session_id.clone(), "other");
+        let executor: TaskBlockExecutor = serde_json::from_value(
+            serde_json::json!({"name":"python","options":{"entry":"main.py"}}),
+        )
+        .unwrap();
+        let (block_event_tx, block_event_rx) = flume::unbounded();
+        let (scheduler_tx, scheduler_rx) = create(
+            CaptureSchedulerTx {
+                block_events: block_event_tx,
+            },
+            PendingSchedulerRx,
+            None,
+            None,
+            test_executor_payload(session_id.clone()),
+            matching_scope.data_dir.clone(),
+        );
+
+        {
+            let mut executor_map = scheduler_rx.executor_map.write().unwrap();
+            for scope in [&matching_scope, &other_scope] {
+                executor_map.insert(
+                    generate_executor_map_name("python", scope),
+                    ExecutorState {
+                        spawn_state: ExecutorSpawnState::Ready,
+                        pid: None,
+                    },
+                );
+            }
+        }
+
+        let scheduler_handle = scheduler_rx.event_loop();
+
+        let (matching_subscriber_tx, matching_subscriber_rx) = flume::unbounded();
+        let (other_subscriber_tx, other_subscriber_rx) = flume::unbounded();
+        scheduler_tx.register_subscriber(matching_job_id.clone(), matching_subscriber_tx);
+        scheduler_tx.register_subscriber(other_job_id.clone(), other_subscriber_tx);
+
+        for (job_id, scope) in [
+            (matching_job_id.clone(), matching_scope.clone()),
+            (other_job_id.clone(), other_scope.clone()),
+        ] {
+            scheduler_tx
+                .tx
+                .send(SchedulerCommand::ExecuteBlock {
+                    job_id,
+                    executor_name: "python".to_string(),
+                    dir: scope.data_dir.clone(),
+                    stacks: vec![],
+                    outputs: None,
+                    executor: executor.clone(),
+                    injection_store: None,
+                    scope,
+                    flow_path: None,
+                })
+                .unwrap();
+        }
+
+        scheduler_tx
+            .tx
+            .send(SchedulerCommand::ExecutorExit {
+                executor: "python-executor".to_string(),
+                identifier: Some(matching_scope.identifier()),
+                code: 1,
+                reason: None,
+            })
+            .unwrap();
+
+        let matching_event = timeout(Duration::from_secs(1), matching_subscriber_rx.recv_async())
+            .await
+            .expect("matching subscriber should receive synthesized finish")
+            .unwrap();
+        assert!(matches!(
+            matching_event,
+            ReceiveMessage::BlockFinished {
+                job_id: ref finished_job_id,
+                ..
+            } if finished_job_id == &matching_job_id
+        ));
+
+        let block_event = timeout(Duration::from_secs(1), block_event_rx.recv_async())
+            .await
+            .expect("broker block event should receive synthesized finish")
+            .unwrap();
+        assert!(matches!(
+            block_event,
+            ReceiveMessage::BlockFinished {
+                job_id: ref finished_job_id,
+                ..
+            } if finished_job_id == &matching_job_id
+        ));
+
+        let other_event = timeout(Duration::from_secs(1), other_subscriber_rx.recv_async())
+            .await
+            .expect("other subscriber should still receive executor lifecycle event")
+            .unwrap();
+        assert!(
+            !matches!(other_event, ReceiveMessage::BlockFinished { .. }),
+            "executor exit should not finish jobs from another identifier"
+        );
+        assert!(
+            block_event_rx.try_recv().is_err(),
+            "executor exit should emit exactly one block finish event"
+        );
+
+        scheduler_tx.abort();
+        scheduler_handle.await.unwrap();
     }
 }

--- a/mainframe/src/scheduler.rs
+++ b/mainframe/src/scheduler.rs
@@ -403,6 +403,14 @@ fn executor_name_matches(running_executor: &str, exited_executor: &str) -> bool 
     trim_executor_suffix(running_executor) == trim_executor_suffix(exited_executor)
 }
 
+fn lifecycle_identifier_matches(event_identifier: Option<&str>, running_identifier: &str) -> bool {
+    match event_identifier {
+        Some(identifier) => identifier == running_identifier,
+        // Legacy unscoped lifecycle commands apply to every matching executor name.
+        None => true,
+    }
+}
+
 fn executor_map_name_from_parts(executor: &str, identifier: Option<&str>) -> String {
     let executor_name = executor.strip_suffix("-executor").unwrap_or(executor);
     match identifier {
@@ -1537,10 +1545,10 @@ where
                                 if !executor_name_matches(&running_block.executor_name, &executor) {
                                     return None;
                                 }
-                                if identifier
-                                    .as_ref()
-                                    .is_some_and(|id| id != &running_block.identifier)
-                                {
+                                if !lifecycle_identifier_matches(
+                                    identifier.as_deref(),
+                                    &running_block.identifier,
+                                ) {
                                     return None;
                                 }
                                 Some(job_id.clone())
@@ -1593,9 +1601,10 @@ where
                             .iter()
                             .filter(|(_, running_block)| {
                                 executor_name_matches(&running_block.executor_name, &executor)
-                                    && identifier
-                                        .as_ref()
-                                        .is_none_or(|id| id == &running_block.identifier)
+                                    && lifecycle_identifier_matches(
+                                        identifier.as_deref(),
+                                        &running_block.identifier,
+                                    )
                             })
                             .map(|(job_id, _)| job_id.clone())
                             .collect::<Vec<_>>();
@@ -1618,21 +1627,6 @@ where
                                 }
                             }
                         }
-
-                        // 理论上有任意一个 block 处理就 OK
-                        subscribers.retain(|_, sender| {
-                            if let Err(e) = sender.send(ReceiveMessage::ExecutorExit {
-                                session_id: session_id.clone(),
-                                executor_name: executor.clone(),
-                                code,
-                                reason: reason.clone(),
-                            }) {
-                                warn!("Scheduler send executor exit to subscriber failed, removing: {e}");
-                                false
-                            } else {
-                                true
-                            }
-                        });
                     }
                     Ok(SchedulerCommand::ReceiveMessage(data)) => {
                         if let Some(msg) = parse_worker_message(data, &session_id) {
@@ -2122,13 +2116,11 @@ mod tests {
             } if finished_job_id == &matching_job_id
         ));
 
-        let other_event = timeout(Duration::from_secs(1), other_subscriber_rx.recv_async())
-            .await
-            .expect("other subscriber should still receive executor lifecycle event")
-            .unwrap();
         assert!(
-            !matches!(other_event, ReceiveMessage::BlockFinished { .. }),
-            "executor exit should not finish jobs from another identifier"
+            timeout(Duration::from_millis(100), other_subscriber_rx.recv_async())
+                .await
+                .is_err(),
+            "executor exit should not notify jobs from another identifier"
         );
         assert!(
             block_event_rx.try_recv().is_err(),

--- a/mainframe/src/scheduler.rs
+++ b/mainframe/src/scheduler.rs
@@ -403,12 +403,21 @@ fn executor_name_matches(running_executor: &str, exited_executor: &str) -> bool 
     trim_executor_suffix(running_executor) == trim_executor_suffix(exited_executor)
 }
 
+fn executor_map_name_from_parts(executor: &str, identifier: Option<&str>) -> String {
+    let executor_name = executor.strip_suffix("-executor").unwrap_or(executor);
+    match identifier {
+        Some(identifier) => format!("{executor_name}-{identifier}"),
+        None => executor_name.to_owned(),
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub enum ExecutorSpawnState {
     #[default]
     None,
     Spawned,  // spawn 但是没有收到 ready 信息
     Ready,    // 收到 ready 信息
+    TimedOut, // executor spawn timed out; late ready messages must be ignored
     Finished, // executor only finished during session finished. This enum is used to indicate that the executor has finished its work and is no longer running. If this state is reached do not try to send executor spawn timeout.
 }
 
@@ -957,13 +966,24 @@ fn spawn_executor(
             tokio::spawn(async move {
                 let status = ch.wait().await;
                 let mut write_map = executor_map_clone.write().unwrap();
-                write_map.insert(
-                    executor_map_name_clone.clone(),
-                    ExecutorState {
-                        spawn_state: ExecutorSpawnState::Finished,
-                        pid: None,
-                    },
-                );
+                match write_map.get_mut(&executor_map_name_clone) {
+                    Some(state) if state.spawn_state == ExecutorSpawnState::TimedOut => {
+                        state.pid = None;
+                    }
+                    Some(state) => {
+                        state.spawn_state = ExecutorSpawnState::Finished;
+                        state.pid = None;
+                    }
+                    None => {
+                        write_map.insert(
+                            executor_map_name_clone.clone(),
+                            ExecutorState {
+                                spawn_state: ExecutorSpawnState::Finished,
+                                pid: None,
+                            },
+                        );
+                    }
+                }
                 drop(write_map);
                 if let Some(layer) = layer {
                     drop(layer);
@@ -1040,6 +1060,13 @@ fn query_executor_state(params: ExecutorCheckParams) -> Result<ExecutorCheckResu
             .unwrap_or_default()
             .spawn_state
     };
+
+    if executor_state == ExecutorSpawnState::TimedOut {
+        return Err(Error::new(&format!(
+            "Executor {executor_name} identifier {} timed out while starting",
+            scope.identifier()
+        )));
+    }
 
     if executor_state != ExecutorSpawnState::None {
         return Ok(ExecutorCheckResult {
@@ -1473,6 +1500,36 @@ where
                         package,
                         identifier,
                     }) => {
+                        let executor_map_name =
+                            executor_map_name_from_parts(&executor, identifier.as_deref());
+                        let timeout_applied = {
+                            let mut write_map = executor_map.write().unwrap();
+                            match write_map.get_mut(&executor_map_name) {
+                                Some(state) if state.spawn_state == ExecutorSpawnState::Spawned => {
+                                    state.spawn_state = ExecutorSpawnState::TimedOut;
+                                    true
+                                }
+                                Some(state) => {
+                                    debug!(
+                                        "Ignore stale spawn timeout for {} in state {:?}",
+                                        executor_map_name, state.spawn_state
+                                    );
+                                    false
+                                }
+                                None => {
+                                    debug!(
+                                        "Ignore spawn timeout for unknown executor {}",
+                                        executor_map_name
+                                    );
+                                    false
+                                }
+                            }
+                        };
+
+                        if !timeout_applied {
+                            continue;
+                        }
+
                         let error_message = format!(
                             "Executor {executor} identifier {identifier:?} for package {package:?} timeout after 5s"
                         );
@@ -1590,29 +1647,46 @@ where
                                     identifier,
                                 } => {
                                     // same as generate_executor_map_name fn logic
-                                    let executor_map_name = if let Some(ref id) = identifier {
-                                        format!("{executor_name}-{id}")
-                                    } else {
-                                        executor_name.clone()
-                                    };
-
-                                    let pid = {
-                                        let read_map = executor_map.read().unwrap();
-                                        read_map
-                                            .get(&executor_map_name)
-                                            .cloned()
-                                            .unwrap_or_default()
-                                            .pid
-                                    };
-
-                                    let mut write_map = executor_map.write().unwrap();
-                                    write_map.insert(
-                                        executor_map_name,
-                                        ExecutorState {
-                                            spawn_state: ExecutorSpawnState::Ready,
-                                            pid,
-                                        },
+                                    let executor_map_name = executor_map_name_from_parts(
+                                        &executor_name,
+                                        identifier.as_deref(),
                                     );
+                                    let ready_accepted = {
+                                        let mut write_map = executor_map.write().unwrap();
+                                        match write_map.get_mut(&executor_map_name) {
+                                            Some(state)
+                                                if matches!(
+                                                    state.spawn_state,
+                                                    ExecutorSpawnState::TimedOut
+                                                        | ExecutorSpawnState::Finished
+                                                ) =>
+                                            {
+                                                debug!(
+                                                    "Ignore late executor ready for {} in state {:?}",
+                                                    executor_map_name, state.spawn_state
+                                                );
+                                                false
+                                            }
+                                            Some(state) => {
+                                                state.spawn_state = ExecutorSpawnState::Ready;
+                                                true
+                                            }
+                                            None => {
+                                                write_map.insert(
+                                                    executor_map_name,
+                                                    ExecutorState {
+                                                        spawn_state: ExecutorSpawnState::Ready,
+                                                        pid: None,
+                                                    },
+                                                );
+                                                true
+                                            }
+                                        }
+                                    };
+
+                                    if !ready_accepted {
+                                        continue;
+                                    }
 
                                     // iterator all subscribers and send executor ready message
                                     subscribers.retain(|_, sender| {
@@ -2061,6 +2135,133 @@ mod tests {
         assert!(
             block_event_rx.try_recv().is_err(),
             "executor exit should emit exactly one block finish event"
+        );
+
+        scheduler_tx.abort();
+        scheduler_handle.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn spawn_timeout_ignores_late_executor_ready() {
+        let session_id = SessionId::random();
+        let job_id = JobId::random();
+        let scope = test_scope(session_id.clone(), "late-ready");
+        let executor: TaskBlockExecutor = serde_json::from_value(
+            serde_json::json!({"name":"python","options":{"entry":"main.py"}}),
+        )
+        .unwrap();
+        let (block_event_tx, block_event_rx) = flume::unbounded();
+        let (scheduler_tx, scheduler_rx) = create(
+            CaptureSchedulerTx {
+                block_events: block_event_tx,
+            },
+            PendingSchedulerRx,
+            None,
+            None,
+            test_executor_payload(session_id.clone()),
+            scope.data_dir.clone(),
+        );
+
+        scheduler_rx.executor_map.write().unwrap().insert(
+            generate_executor_map_name("python", &scope),
+            ExecutorState {
+                spawn_state: ExecutorSpawnState::Spawned,
+                pid: Some(42),
+            },
+        );
+        let executor_map = scheduler_rx.executor_map.clone();
+        let scheduler_handle = scheduler_rx.event_loop();
+
+        let (subscriber_tx, subscriber_rx) = flume::unbounded();
+        scheduler_tx.register_subscriber(job_id.clone(), subscriber_tx);
+        scheduler_tx
+            .tx
+            .send(SchedulerCommand::ExecuteBlock {
+                job_id: job_id.clone(),
+                executor_name: "python".to_string(),
+                dir: scope.data_dir.clone(),
+                stacks: vec![],
+                outputs: None,
+                executor,
+                injection_store: None,
+                scope: scope.clone(),
+                flow_path: None,
+            })
+            .unwrap();
+        scheduler_tx
+            .tx
+            .send(SchedulerCommand::SpawnExecutorTimeout {
+                executor: "python-executor".to_string(),
+                package: None,
+                identifier: Some(scope.identifier()),
+            })
+            .unwrap();
+
+        let subscriber_event = timeout(Duration::from_secs(1), subscriber_rx.recv_async())
+            .await
+            .expect("subscriber should receive synthesized timeout finish")
+            .unwrap();
+        assert!(matches!(
+            subscriber_event,
+            ReceiveMessage::BlockFinished {
+                job_id: ref finished_job_id,
+                error: Some(ref error),
+                ..
+            } if finished_job_id == &job_id
+                && error == &format!(
+                    "Executor python-executor identifier {:?} for package None timeout after 5s",
+                    Some(scope.identifier())
+                )
+        ));
+
+        let block_event = timeout(Duration::from_secs(1), block_event_rx.recv_async())
+            .await
+            .expect("broker block event should receive synthesized timeout finish")
+            .unwrap();
+        assert!(matches!(
+            block_event,
+            ReceiveMessage::BlockFinished {
+                job_id: ref finished_job_id,
+                ..
+            } if finished_job_id == &job_id
+        ));
+
+        let timeout_event = timeout(Duration::from_secs(1), subscriber_rx.recv_async())
+            .await
+            .expect("subscriber should receive executor timeout lifecycle event")
+            .unwrap();
+        assert!(matches!(
+            timeout_event,
+            ReceiveMessage::ExecutorTimeout { .. }
+        ));
+
+        scheduler_tx
+            .tx
+            .send(SchedulerCommand::ReceiveMessage(
+                serde_json::to_vec(&ReceiveMessage::ExecutorReady {
+                    session_id: session_id.clone(),
+                    executor_name: "python".to_string(),
+                    package: None,
+                    identifier: Some(scope.identifier()),
+                })
+                .unwrap(),
+            ))
+            .unwrap();
+
+        assert!(
+            timeout(Duration::from_millis(100), subscriber_rx.recv_async())
+                .await
+                .is_err(),
+            "late executor ready should not be forwarded to subscriber"
+        );
+        assert_eq!(
+            executor_map
+                .read()
+                .unwrap()
+                .get(&generate_executor_map_name("python", &scope))
+                .unwrap()
+                .spawn_state,
+            ExecutorSpawnState::TimedOut
         );
 
         scheduler_tx.abort();

--- a/runtime/src/block_job/listener.rs
+++ b/runtime/src/block_job/listener.rs
@@ -79,6 +79,20 @@ fn is_json_serializable(
 }
 
 pub fn listen_to_worker(params: ListenerParameters) -> tokio::task::JoinHandle<()> {
+    let block_scope = params.scheduler_tx.calculate_scope(&params.scope);
+    let (job_tx, job_rx) = flume::unbounded::<scheduler::ReceiveMessage>();
+    params
+        .scheduler_tx
+        .register_subscriber(params.job_id.to_owned(), job_tx);
+
+    listen_to_worker_messages(params, block_scope, job_rx)
+}
+
+fn listen_to_worker_messages(
+    params: ListenerParameters,
+    block_scope: RuntimeScope,
+    job_rx: flume::Receiver<scheduler::ReceiveMessage>,
+) -> tokio::task::JoinHandle<()> {
     let ListenerParameters {
         job_id,
         block_path,
@@ -98,11 +112,6 @@ pub fn listen_to_worker(params: ListenerParameters) -> tokio::task::JoinHandle<(
         flow_path,
     } = params;
 
-    let block_scope = scheduler_tx.calculate_scope(&scope);
-
-    let (job_tx, job_rx) = flume::unbounded::<scheduler::ReceiveMessage>();
-
-    scheduler_tx.register_subscriber(job_id.to_owned(), job_tx);
     tokio::spawn(async move {
         let run_block = |executor: Option<&Arc<TaskBlockExecutor>>,
                          service: Option<&ServiceExecutorPayload>| {
@@ -480,6 +489,27 @@ mod tests {
         panic!("listener did not subscribe to scheduler messages");
     }
 
+    fn assert_done_error(
+        status: crate::block_status::Status,
+        job_id: &JobId,
+        expected_error: &str,
+    ) {
+        match status {
+            crate::block_status::Status::Done {
+                job_id: done_job_id,
+                result,
+                error,
+                error_detail,
+            } => {
+                assert_eq!(done_job_id, *job_id);
+                assert!(result.is_none());
+                assert_eq!(error.as_deref(), Some(expected_error));
+                assert!(error_detail.is_none());
+            }
+            _ => panic!("expected done error status"),
+        }
+    }
+
     #[tokio::test]
     async fn listener_finishes_block_from_scheduler_block_finished_error() {
         let session_id = SessionId::random();
@@ -537,26 +567,100 @@ mod tests {
             .expect("listener should emit block status")
             .expect("block status channel should stay open");
 
-        match status {
-            crate::block_status::Status::Done {
-                job_id: done_job_id,
-                result,
-                error,
-                error_detail,
-            } => {
-                assert_eq!(done_job_id, job_id);
-                assert!(result.is_none());
-                assert_eq!(
-                    error.as_deref(),
-                    Some("Executor python-executor exit with code 1")
-                );
-                assert!(error_detail.is_none());
-            }
-            _ => panic!("expected done error status"),
-        }
+        assert_done_error(status, &job_id, "Executor python-executor exit with code 1");
 
         scheduler_tx.abort();
         scheduler_handle.await.unwrap();
+        listener_handle.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn listener_waits_for_block_finished_after_executor_lifecycle_messages() {
+        let session_id = SessionId::random();
+        let job_id = JobId::random();
+        let scope = test_scope(session_id.clone());
+        let (_worker_tx, worker_rx) = flume::unbounded();
+        let (scheduler_tx, _scheduler_rx) = scheduler::create(
+            NoopSchedulerTx,
+            ChannelSchedulerRx { rx: worker_rx },
+            None,
+            None,
+            test_executor_payload(session_id.clone()),
+            scope.data_dir.clone(),
+        );
+
+        let (reporter_tx, _reporter_rx) =
+            reporter::create::<NoopReporterTx, NoopReporterRx>(session_id.clone(), None, None);
+        let reporter = Arc::new(reporter_tx.block(job_id.clone(), None, BlockJobStacks::new()));
+        let (block_status_tx, block_status_rx) = crate::block_status::create();
+        let (job_tx, job_rx) = flume::unbounded();
+        let block_scope = scheduler_tx.calculate_scope(&scope);
+        let listener_handle = listen_to_worker_messages(
+            ListenerParameters {
+                job_id: job_id.clone(),
+                block_path: None,
+                stacks: BlockJobStacks::new(),
+                scheduler_tx,
+                inputs: None,
+                outputs_def: None,
+                inputs_def: None,
+                inputs_def_patch: None,
+                block_status: block_status_tx,
+                reporter,
+                executor: None,
+                service: None,
+                block_dir: scope.data_dir.clone(),
+                scope: scope.clone(),
+                injection_store: None,
+                flow_path: None,
+            },
+            block_scope,
+            job_rx,
+        );
+
+        job_tx
+            .send_async(scheduler::ReceiveMessage::ExecutorExit {
+                session_id: session_id.clone(),
+                executor_name: "python".to_string(),
+                code: 1,
+                reason: None,
+            })
+            .await
+            .unwrap();
+        job_tx
+            .send_async(scheduler::ReceiveMessage::ExecutorTimeout {
+                session_id: session_id.clone(),
+                executor_name: "python".to_string(),
+                package: None,
+                identifier: Some(scope.identifier()),
+            })
+            .await
+            .unwrap();
+
+        assert!(
+            timeout(Duration::from_millis(100), block_status_rx.recv())
+                .await
+                .is_err(),
+            "executor lifecycle messages should not finish blocks directly"
+        );
+
+        job_tx
+            .send_async(scheduler::ReceiveMessage::BlockFinished {
+                session_id,
+                job_id: job_id.clone(),
+                result: None,
+                error: Some("Executor python-executor exit with code 1".to_string()),
+            })
+            .await
+            .unwrap();
+
+        let status = timeout(Duration::from_secs(1), block_status_rx.recv())
+            .await
+            .expect("listener should emit block status")
+            .expect("block status channel should stay open");
+        assert_done_error(status, &job_id, "Executor python-executor exit with code 1");
+
+        drop(job_tx);
         listener_handle.await.unwrap();
     }
 }

--- a/runtime/src/block_job/listener.rs
+++ b/runtime/src/block_job/listener.rs
@@ -343,3 +343,220 @@ pub fn listen_to_worker(params: ListenerParameters) -> tokio::task::JoinHandle<(
         }
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use job::{BlockJobStacks, SessionId};
+    use mainframe::{
+        MessageData,
+        reporter::{self, ReporterRxImpl, ReporterTxImpl},
+        scheduler::{ExecutorParameters, SchedulerRxImpl, SchedulerTxImpl},
+    };
+    use tokio::time::{Duration, timeout};
+
+    struct NoopSchedulerTx;
+
+    #[async_trait]
+    impl SchedulerTxImpl for NoopSchedulerTx {
+        async fn send_block_event(&self, _session_id: &SessionId, _data: MessageData) {}
+
+        async fn send_inputs(&self, _job_id: &JobId, _data: MessageData) {}
+
+        async fn run_block(&self, _executor_name: &str, _data: MessageData) {}
+
+        async fn respond_block_request(
+            &self,
+            _session_id: &SessionId,
+            _request_id: &str,
+            _data: MessageData,
+        ) {
+        }
+
+        async fn run_service_block(&self, _executor_name: &str, _data: MessageData) {}
+
+        async fn disconnect(&self) {}
+    }
+
+    struct ChannelSchedulerRx {
+        rx: flume::Receiver<MessageData>,
+    }
+
+    #[async_trait]
+    impl SchedulerRxImpl for ChannelSchedulerRx {
+        async fn recv(&mut self) -> MessageData {
+            self.rx.recv_async().await.unwrap_or_default()
+        }
+    }
+
+    struct NoopReporterTx;
+
+    #[async_trait]
+    impl ReporterTxImpl for NoopReporterTx {
+        async fn send(&self, _data: MessageData) {}
+
+        async fn disconnect(&self) {}
+    }
+
+    struct NoopReporterRx;
+
+    impl ReporterRxImpl for NoopReporterRx {
+        fn event_loop(self) -> tokio::task::JoinHandle<()> {
+            tokio::spawn(async {})
+        }
+    }
+
+    fn test_scope(session_id: SessionId) -> RuntimeScope {
+        let root = std::env::temp_dir();
+        RuntimeScope {
+            session_id,
+            pkg_name: None,
+            data_dir: root.display().to_string(),
+            pkg_root: root.clone(),
+            path: root,
+            node_id: None,
+            is_inject: false,
+            enable_layer: false,
+        }
+    }
+
+    fn test_executor_payload(session_id: SessionId) -> ExecutorParameters {
+        ExecutorParameters {
+            addr: "127.0.0.1:0".to_string(),
+            session_id,
+            session_dir: std::env::temp_dir().display().to_string(),
+            pass_through_env_keys: vec![],
+            bind_paths: vec![],
+            env_file: None,
+            tmp_dir: std::env::temp_dir(),
+            debug: false,
+            wait_for_client: false,
+        }
+    }
+
+    async fn send_worker_message(
+        worker_tx: &flume::Sender<MessageData>,
+        message: scheduler::ReceiveMessage,
+    ) {
+        worker_tx
+            .send_async(serde_json::to_vec(&message).unwrap())
+            .await
+            .unwrap();
+    }
+
+    async fn wait_for_listener_subscription(
+        worker_tx: &flume::Sender<MessageData>,
+        block_status_rx: &crate::block_status::BlockStatusRx,
+        session_id: &SessionId,
+        job_id: &JobId,
+    ) {
+        for _ in 0..20 {
+            send_worker_message(
+                worker_tx,
+                scheduler::ReceiveMessage::BlockProgress {
+                    session_id: session_id.clone(),
+                    job_id: job_id.clone(),
+                    progress: 42.0,
+                },
+            )
+            .await;
+
+            match timeout(Duration::from_millis(50), block_status_rx.recv()).await {
+                Ok(Some(crate::block_status::Status::Progress {
+                    job_id: progress_job_id,
+                    progress,
+                })) => {
+                    assert_eq!(progress_job_id, *job_id);
+                    assert_eq!(progress, 42.0);
+                    return;
+                }
+                Ok(Some(_)) => panic!("expected progress status"),
+                Ok(None) => panic!("block status channel closed"),
+                Err(_) => {}
+            }
+        }
+
+        panic!("listener did not subscribe to scheduler messages");
+    }
+
+    #[tokio::test]
+    async fn listener_finishes_block_from_scheduler_block_finished_error() {
+        let session_id = SessionId::random();
+        let job_id = JobId::random();
+        let scope = test_scope(session_id.clone());
+        let (worker_tx, worker_rx) = flume::unbounded();
+        let (scheduler_tx, scheduler_rx) = scheduler::create(
+            NoopSchedulerTx,
+            ChannelSchedulerRx { rx: worker_rx },
+            None,
+            None,
+            test_executor_payload(session_id.clone()),
+            scope.data_dir.clone(),
+        );
+        let scheduler_handle = scheduler_rx.event_loop();
+
+        let (reporter_tx, _reporter_rx) =
+            reporter::create::<NoopReporterTx, NoopReporterRx>(session_id.clone(), None, None);
+        let reporter = Arc::new(reporter_tx.block(job_id.clone(), None, BlockJobStacks::new()));
+        let (block_status_tx, block_status_rx) = crate::block_status::create();
+        let listener_handle = listen_to_worker(ListenerParameters {
+            job_id: job_id.clone(),
+            block_path: None,
+            stacks: BlockJobStacks::new(),
+            scheduler_tx: scheduler_tx.clone(),
+            inputs: None,
+            outputs_def: None,
+            inputs_def: None,
+            inputs_def_patch: None,
+            block_status: block_status_tx,
+            reporter,
+            executor: None,
+            service: None,
+            block_dir: scope.data_dir.clone(),
+            scope,
+            injection_store: None,
+            flow_path: None,
+        });
+
+        wait_for_listener_subscription(&worker_tx, &block_status_rx, &session_id, &job_id).await;
+
+        send_worker_message(
+            &worker_tx,
+            scheduler::ReceiveMessage::BlockFinished {
+                session_id: session_id.clone(),
+                job_id: job_id.clone(),
+                result: None,
+                error: Some("Executor python-executor exit with code 1".to_string()),
+            },
+        )
+        .await;
+
+        let status = timeout(Duration::from_secs(1), block_status_rx.recv())
+            .await
+            .expect("listener should emit block status")
+            .expect("block status channel should stay open");
+
+        match status {
+            crate::block_status::Status::Done {
+                job_id: done_job_id,
+                result,
+                error,
+                error_detail,
+            } => {
+                assert_eq!(done_job_id, job_id);
+                assert!(result.is_none());
+                assert_eq!(
+                    error.as_deref(),
+                    Some("Executor python-executor exit with code 1")
+                );
+                assert!(error_detail.is_none());
+            }
+            _ => panic!("expected done error status"),
+        }
+
+        scheduler_tx.abort();
+        scheduler_handle.await.unwrap();
+        listener_handle.await.unwrap();
+    }
+}

--- a/runtime/src/block_job/listener.rs
+++ b/runtime/src/block_job/listener.rs
@@ -190,11 +190,7 @@ pub fn listen_to_worker(params: ListenerParameters) -> tokio::task::JoinHandle<(
                     reason,
                     ..
                 } => {
-                    let msg =
-                        reason.unwrap_or(format!("Executor {executor_name} exit with code {code}"));
-
-                    reporter.finished(None, Some(msg.clone()));
-                    block_status.error(msg);
+                    debug!("executor {executor_name} exited with code {code}, reason: {reason:?}");
                 }
                 scheduler::ReceiveMessage::ExecutorTimeout {
                     executor_name,
@@ -215,12 +211,9 @@ pub fn listen_to_worker(params: ListenerParameters) -> tokio::task::JoinHandle<(
                         continue;
                     }
 
-                    let error_message = format!(
+                    debug!(
                         "Executor {executor_name} identifier {identifier:?} for package {package:?} timeout after 5s"
                     );
-
-                    block_status.error(error_message.clone());
-                    reporter.finished(None, Some(error_message));
                 }
                 scheduler::ReceiveMessage::BlockReady { job_id, .. } => {
                     has_executor_response = true;


### PR DESCRIPTION
## Summary
- track running block jobs in the scheduler by executor and scope identifier
- when an executor exits or times out, synthesize a job-scoped BlockFinished(error) event for affected running blocks before the session can finish
- scope ExecutorExit by identifier so same executor under another scope is not failed accidentally
- keep listener handling on the normal BlockFinished path so block reporter/status updates are not skipped

## Tests
- cargo fmt --check
- cargo test -p mainframe
- cargo test -p runtime
- cargo clippy -p mainframe --all-targets -- -D warnings

## Notes
- cargo clippy -p runtime --all-targets -- -D warnings still fails on pre-existing test lint issues outside this PR: await_holding_lock in connector tests and ptr_arg in TestRuntime::new.