### PR TITLE
fix(utils): expand run extra search paths

### DIFF
--- a/utils/src/config/run_config.rs
+++ b/utils/src/config/run_config.rs
@@ -1,6 +1,8 @@
-use crate::path::expand_home;
 use serde::{Deserialize, Serialize};
 
+use crate::path::expand_home;
+
+#[derive(Deserialize)]
 struct TmpRunExtraConfig {
     pub search_paths: Option<Vec<String>>,
 }
@@ -19,6 +21,7 @@ impl From<TmpRunExtraConfig> for RunExtraConfig {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(from = "TmpRunExtraConfig")]
 pub struct RunExtraConfig {
     pub search_paths: Option<Vec<String>>,
 }

--- a/utils/tests/run_extra_paths.toml
+++ b/utils/tests/run_extra_paths.toml
@@ -1,0 +1,9 @@
+[global]
+store_dir = "~/.oomol-studio/oocana"
+oocana_dir = "~/.oocana"
+
+[run]
+broker = "127.0.0.1:47688"
+
+[run.extra]
+search_paths = ["~/run-extra", "$HOME/run-extra-env"]

--- a/utils/tests/test.rs
+++ b/utils/tests/test.rs
@@ -48,6 +48,24 @@ mod tests {
     }
 
     #[test]
+    fn test_run_extra_search_paths_expand_home() {
+        let config = load_config(Some("tests/run_extra_paths.toml"));
+        assert!(config.is_ok(), "Error: {:?}", config.unwrap_err());
+
+        let config = config.unwrap();
+        let home_dir = dirs::home_dir().unwrap().to_string_lossy().to_string();
+        let extra = config.run.extra.unwrap();
+
+        assert_eq!(
+            extra.search_paths,
+            Some(vec![
+                format!("{home_dir}/run-extra"),
+                format!("{home_dir}/run-extra-env"),
+            ])
+        );
+    }
+
+    #[test]
     fn test_load_env_from_file() {
         let file_path = Some("tests/test.env");
         let env_vars = load_env_from_file(&file_path);


### PR DESCRIPTION
## Summary
- expand `run.extra.search_paths` with the existing home-path normalization path
- add a config fixture covering both `~` and `$HOME` entries

## Verification
- `cargo test -p utils --test test test_run_extra_search_paths_expand_home`
- `env HOME=/private/tmp/oocana-rust-home RUSTUP_HOME=/Users/yleaf/.rustup CARGO_HOME=/Users/yleaf/.cargo cargo test -p utils`
- `cargo check --workspace`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/oomol/codesmith/oocana-rust/pr/470"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->