### PR TITLE
ci: migrate workflows to Blacksmith runners

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -44,7 +44,7 @@ jobs:
         uses: leavesster/duplicate-run-action@v0.1
 
   rust-test:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     needs: [skip, check-duplicate]
     if: ${{ needs.skip.outputs.should_skip != 'true' && needs.check-duplicate.outputs.is_duplicate != 'true' }}
     timeout-minutes: 20
@@ -80,7 +80,7 @@ jobs:
     needs: [skip, rust-test]
     uses: ./.github/workflows/oocana-python.yml
   build:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     needs: [skip, check-duplicate, rust-test, python-test, node-test]
     if: ${{ always() }}
     steps:

--- a/.github/workflows/layer.yml
+++ b/.github/workflows/layer.yml
@@ -36,7 +36,7 @@ jobs:
             - "!layer/**.md"
 
   rust-test:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     container:
       image: rust:1.88-bookworm@sha256:af306cfa71d987911a781c37b59d7d67d934f49684058f96cf72079c3626bfe0
       options: --privileged
@@ -97,7 +97,7 @@ jobs:
       ovmlayer-repository: ${{ vars.OVMLAYER_REPOSITORY }}
     secrets: inherit
   layer-build:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     needs: [skip, rust-test, python-test, node-test]
     if: ${{ always() }}
     steps:

--- a/.github/workflows/oocana-node.yml
+++ b/.github/workflows/oocana-node.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   test-node:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     container:
       image: ubuntu:24.04@sha256:186072bba1b2f436cbb91ef2567abca677337cfc786c86e107d25b7072feef0c
       options: --privileged --user 0:0

--- a/.github/workflows/oocana-python.yml
+++ b/.github/workflows/oocana-python.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   test-python:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     container:
       image: ubuntu:24.04@sha256:186072bba1b2f436cbb91ef2567abca677337cfc786c86e107d25b7072feef0c
       options: --privileged --user 0:0

--- a/.github/workflows/ovmlayer.yml
+++ b/.github/workflows/ovmlayer.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   ovmlayer:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     env:
       OVMLAYER_REPOSITORY: ${{ inputs.repository || vars.OVMLAYER_REPOSITORY || 'ovmlayer-next' }}
       OVMLAYER_USE_RUNTIME_SETUP: ${{ (inputs.repository || vars.OVMLAYER_REPOSITORY || 'ovmlayer-next') == (vars.OVMLAYER_REPOSITORY || 'ovmlayer-next') }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ jobs:
             echo "result=true" >> $GITHUB_OUTPUT
           fi
   release-ubuntu:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     strategy:
       matrix:
         target: [
@@ -69,7 +69,7 @@ jobs:
           make_latest: true
 
   release-macos:
-    runs-on: [macos-latest]
+    runs-on: blacksmith-6vcpu-macos-latest
     needs: [dry-run]
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
Copies the workflow runner migration from #469.

This changes selected GitHub Actions jobs to run on Blacksmith runners.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/oomol/codesmith/oocana-rust/pr/471"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->